### PR TITLE
UI polish for Workout screen: denser layout and safe delete

### DIFF
--- a/app/src/main/java/com/noahjutz/gymroutines/ui/workout/in_progress/WorkoutInProgress.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/workout/in_progress/WorkoutInProgress.kt
@@ -28,15 +28,17 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.selection.toggleable
@@ -47,6 +49,7 @@ import androidx.compose.material.Button
 import androidx.compose.material.Card
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.DismissValue
+import androidx.compose.material.Divider
 import androidx.compose.material.DropdownMenu
 import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.ExperimentalMaterialApi
@@ -56,28 +59,43 @@ import androidx.compose.material.MaterialTheme.colors
 import androidx.compose.material.MaterialTheme.typography
 import androidx.compose.material.OutlinedButton
 import androidx.compose.material.Scaffold
+import androidx.compose.material.ScaffoldState
+import androidx.compose.material.SnackbarResult
 import androidx.compose.material.Surface
 import androidx.compose.material.SwipeToDismiss
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
+import androidx.compose.material.rememberDismissState
+import androidx.compose.material.rememberScaffoldState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.DragHandle
-import androidx.compose.material.rememberDismissState
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.noahjutz.gymroutines.R
+import com.noahjutz.gymroutines.data.domain.WorkoutSet
+import com.noahjutz.gymroutines.data.domain.WorkoutSetGroupWithSets
 import com.noahjutz.gymroutines.data.domain.WorkoutWithSetGroups
 import com.noahjutz.gymroutines.data.domain.duration
 import com.noahjutz.gymroutines.ui.components.AutoSelectTextField
@@ -86,10 +104,11 @@ import com.noahjutz.gymroutines.ui.components.TopBar
 import com.noahjutz.gymroutines.ui.components.durationVisualTransformation
 import com.noahjutz.gymroutines.util.RegexPatterns
 import com.noahjutz.gymroutines.util.formatSimple
-import com.noahjutz.gymroutines.util.pretty
 import com.noahjutz.gymroutines.util.toStringOrBlank
 import org.koin.androidx.compose.getViewModel
 import org.koin.core.parameter.parametersOf
+import java.util.Locale
+import kotlinx.coroutines.launch
 
 @ExperimentalFoundationApi
 @ExperimentalAnimationApi
@@ -107,7 +126,9 @@ fun WorkoutInProgress(
         viewModel.addExercises(exerciseIdsToAdd)
     }
 
+    val scaffoldState = rememberScaffoldState()
     Scaffold(
+        scaffoldState = scaffoldState,
         topBar = {
             TopBar(
                 title = stringResource(R.string.screen_perform_workout),
@@ -132,13 +153,13 @@ fun WorkoutInProgress(
                         popBackStack = popBackStack,
                         navToExercisePicker = navToExercisePicker,
                         navToWorkoutCompleted = navToWorkoutCompleted,
+                        scaffoldState = scaffoldState,
                     )
                 }
             }
         }
     }
 }
-
 @OptIn(
     ExperimentalMaterialApi::class,
     ExperimentalFoundationApi::class
@@ -150,6 +171,7 @@ private fun WorkoutInProgressContent(
     popBackStack: () -> Unit,
     navToExercisePicker: () -> Unit,
     navToWorkoutCompleted: (Int, Int) -> Unit,
+    scaffoldState: ScaffoldState,
 ) {
     var showFinishWorkoutDialog by remember { mutableStateOf(false) }
     if (showFinishWorkoutDialog) FinishWorkoutDialog(
@@ -169,29 +191,74 @@ private fun WorkoutInProgressContent(
         }
     )
 
-    LazyColumn(Modifier.fillMaxHeight()) {
+    val coroutineScope = rememberCoroutineScope()
+    var setPendingDeletion by remember { mutableStateOf<WorkoutSet?>(null) }
+    var pendingSetGroup by remember { mutableStateOf<WorkoutSetGroupWithSets?>(null) }
+    val deleteMessage = stringResource(R.string.snackbar_set_removed)
+    val undoLabel = stringResource(R.string.action_undo)
+
+    if (setPendingDeletion != null) {
+        ConfirmDeleteSetDialog(
+            onDismiss = {
+                setPendingDeletion = null
+                pendingSetGroup = null
+            },
+            onConfirm = {
+                val setToDelete = setPendingDeletion
+                val groupToRestore = pendingSetGroup?.group
+                if (setToDelete != null) {
+                    viewModel.deleteSet(setToDelete)
+                    coroutineScope.launch {
+                        val result = scaffoldState.snackbarHostState.showSnackbar(
+                            message = deleteMessage,
+                            actionLabel = undoLabel,
+                        )
+                        if (result == SnackbarResult.ActionPerformed) {
+                            viewModel.restoreSet(setToDelete, groupToRestore)
+                        }
+                    }
+                }
+                setPendingDeletion = null
+                pendingSetGroup = null
+            }
+        )
+    }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxHeight(),
+        contentPadding = PaddingValues(bottom = 24.dp)
+    ) {
         item {
             Surface(
                 Modifier
                     .fillMaxWidth()
-                    .padding(top = 24.dp, start = 24.dp, end = 24.dp),
-                color = colors.onSurface.copy(alpha = 0.1f),
-                shape = RoundedCornerShape(24.dp)
+                    .padding(horizontal = 24.dp, vertical = 16.dp),
+                color = colors.surface,
+                shape = RoundedCornerShape(16.dp)
             ) {
                 val routineName by viewModel.routineName.collectAsState("")
                 Text(
                     text = routineName,
-                    modifier = Modifier.padding(24.dp),
-                    style = typography.h3,
+                    modifier = Modifier.padding(horizontal = 20.dp, vertical = 16.dp),
+                    style = typography.h5,
                 )
             }
-            Text(
-                workout.workout.duration.pretty(),
-                Modifier
-                    .fillMaxWidth()
-                    .padding(top = 24.dp, start = 24.dp, end = 24.dp),
-                style = typography.h4.copy(textAlign = TextAlign.Center)
-            )
+            val duration = workout.workout.duration
+            val totalSeconds = duration.inWholeSeconds
+            if (totalSeconds > 0) {
+                val minutes = (totalSeconds / 60).toInt()
+                val seconds = (totalSeconds % 60).toInt()
+                Text(
+                    String.format(Locale.getDefault(), "%02d:%02d", minutes, seconds),
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 24.dp),
+                    style = typography.body2.copy(
+                        textAlign = TextAlign.Center,
+                        color = colors.onSurface.copy(alpha = 0.7f),
+                    )
+                )
+            }
         }
 
         items(workout.setGroups.sortedBy { it.group.position }, key = { it.group.id }) { setGroup ->
@@ -201,330 +268,327 @@ private fun WorkoutInProgressContent(
                 Modifier
                     .fillMaxWidth()
                     .animateItemPlacement()
-                    .padding(top = 24.dp),
-                shape = RoundedCornerShape(24.dp),
+                    .padding(horizontal = 24.dp, vertical = 12.dp),
+                shape = RoundedCornerShape(20.dp),
             ) {
                 Column {
-                    Surface(Modifier.fillMaxWidth(), color = colors.primary) {
-                        Row(
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Text(
-                                exercise?.name.toString(),
-                                style = typography.h5,
-                                modifier = Modifier
-                                    .padding(16.dp)
-                                    .weight(1f)
-                            )
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 12.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        val exerciseName = exercise?.name.orEmpty()
+                        Text(
+                            exerciseName,
+                            style = typography.h6,
+                            modifier = Modifier
+                                .weight(1f)
+                                .semantics { contentDescription = exerciseName }
+                                .padding(end = 8.dp),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
 
-                            Box {
-                                var expanded by remember { mutableStateOf(false) }
-                                IconButton(
-                                    modifier = Modifier.padding(16.dp),
-                                    onClick = { expanded = !expanded }
+                        Box {
+                            var expanded by remember { mutableStateOf(false) }
+                            IconButton(onClick = { expanded = !expanded }) {
+                                Icon(
+                                    Icons.Default.DragHandle,
+                                    stringResource(R.string.drag_handle)
+                                )
+                            }
+                            DropdownMenu(
+                                expanded = expanded,
+                                onDismissRequest = { expanded = false }
+                            ) {
+                                DropdownMenuItem(
+                                    onClick = {
+                                        expanded = false
+                                        val id = setGroup.group.id
+                                        val toId = workout.setGroups
+                                            .find { it.group.position == setGroup.group.position - 1 }
+                                            ?.group
+                                            ?.id
+                                        if (toId != null) {
+                                            viewModel.swapSetGroups(id, toId)
+                                        }
+                                    }
                                 ) {
-                                    Icon(
-                                        Icons.Default.DragHandle,
-                                        stringResource(R.string.drag_handle)
-                                    )
+                                    Text(stringResource(R.string.btn_move_up))
                                 }
-                                DropdownMenu(
-                                    expanded = expanded,
-                                    onDismissRequest = { expanded = false }
+                                DropdownMenuItem(
+                                    onClick = {
+                                        expanded = false
+                                        val id = setGroup.group.id
+                                        val toId = workout.setGroups
+                                            .find { it.group.position == setGroup.group.position + 1 }
+                                            ?.group
+                                            ?.id
+                                        if (toId != null) {
+                                            viewModel.swapSetGroups(id, toId)
+                                        }
+                                    }
                                 ) {
-                                    DropdownMenuItem(
-                                        onClick = {
-                                            expanded = false
-                                            val id = setGroup.group.id
-                                            val toId = workout.setGroups
-                                                .find { it.group.position == setGroup.group.position - 1 }
-                                                ?.group
-                                                ?.id
-                                            if (toId != null) {
-                                                viewModel.swapSetGroups(id, toId)
-                                            }
-                                        }
-                                    ) {
-                                        Text(stringResource(R.string.btn_move_up))
-                                    }
-                                    DropdownMenuItem(
-                                        onClick = {
-                                            expanded = false
-                                            val id = setGroup.group.id
-                                            val toId = workout.setGroups
-                                                .find { it.group.position == setGroup.group.position + 1 }
-                                                ?.group
-                                                ?.id
-                                            if (toId != null) {
-                                                viewModel.swapSetGroups(id, toId)
-                                            }
-                                        }
-                                    ) {
-                                        Text(stringResource(R.string.btn_move_down))
-                                    }
+                                    Text(stringResource(R.string.btn_move_down))
                                 }
                             }
                         }
                     }
-                    Column(Modifier.padding(vertical = 16.dp)) {
-                        Row(Modifier.padding(horizontal = 4.dp)) {
-                            val headerTextStyle = TextStyle(
-                                color = colors.onSurface,
-                                fontSize = 16.sp,
-                                fontWeight = FontWeight.Bold,
-                                textAlign = TextAlign.Center
+                    Divider()
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        val headerTextStyle = TextStyle(
+                            color = colors.onSurface.copy(alpha = 0.72f),
+                            fontSize = 14.sp,
+                            fontWeight = FontWeight.SemiBold,
+                            textAlign = TextAlign.End
+                        )
+                        if (exercise?.logReps == true) {
+                            Text(
+                                stringResource(R.string.column_reps),
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .padding(horizontal = 8.dp),
+                                style = headerTextStyle
                             )
-                            if (exercise?.logReps == true) Box(
-                                Modifier
-                                    .padding(4.dp)
+                        }
+                        if (exercise?.logWeight == true) {
+                            Text(
+                                stringResource(R.string.column_weight_with_unit),
+                                modifier = Modifier
                                     .weight(1f)
-                                    .height(56.dp)
-                                    .clip(RoundedCornerShape(8.dp))
-                                    .background(colors.primary.copy(alpha = 0.1f)),
-                                contentAlignment = Alignment.Center
-                            ) {
-                                Text(
-                                    stringResource(R.string.column_reps),
-                                    style = headerTextStyle
-                                )
-                            }
-                            if (exercise?.logWeight == true) Box(
-                                Modifier
-                                    .padding(4.dp)
+                                    .padding(horizontal = 8.dp),
+                                style = headerTextStyle
+                            )
+                        }
+                        if (exercise?.logTime == true) {
+                            Text(
+                                stringResource(R.string.column_time),
+                                modifier = Modifier
                                     .weight(1f)
-                                    .height(56.dp)
-                                    .clip(RoundedCornerShape(8.dp))
-                                    .background(colors.primary.copy(alpha = 0.1f)),
-                                contentAlignment = Alignment.Center
-                            ) {
-                                Text(
-                                    stringResource(R.string.column_weight),
-                                    style = headerTextStyle
-                                )
-                            }
-                            if (exercise?.logTime == true) Box(
-                                Modifier
-                                    .padding(4.dp)
+                                    .padding(horizontal = 8.dp),
+                                style = headerTextStyle
+                            )
+                        }
+                        if (exercise?.logDistance == true) {
+                            Text(
+                                stringResource(R.string.column_distance),
+                                modifier = Modifier
                                     .weight(1f)
-                                    .height(56.dp)
-                                    .clip(RoundedCornerShape(8.dp))
-                                    .background(colors.primary.copy(alpha = 0.1f)),
-                                contentAlignment = Alignment.Center
-                            ) {
-                                Text(
-                                    stringResource(R.string.column_time),
-                                    style = headerTextStyle
-                                )
-                            }
-                            if (exercise?.logDistance == true) Box(
-                                Modifier
-                                    .padding(4.dp)
-                                    .weight(1f)
-                                    .height(56.dp)
-                                    .clip(RoundedCornerShape(8.dp))
-                                    .background(colors.primary.copy(alpha = 0.1f)),
-                                contentAlignment = Alignment.Center
-                            ) {
-                                Text(
-                                    stringResource(R.string.column_distance),
-                                    style = headerTextStyle
-                                )
-                            }
+                                    .padding(horizontal = 8.dp),
+                                style = headerTextStyle
+                            )
+                        }
+                        Box(
+                            modifier = Modifier
+                                .widthIn(min = 48.dp)
+                                .padding(start = 8.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Icon(
+                                Icons.Default.Check,
+                                stringResource(R.string.column_set_complete),
+                                tint = colors.onSurface.copy(alpha = 0.72f)
+                            )
+                        }
+                    }
+                    Divider()
+                    Column {
+                        val textFieldStyle = typography.body1.copy(
+                            textAlign = TextAlign.End,
+                            color = colors.onSurface,
+                            fontFeatureSettings = "tnum"
+                        )
+                        val cellDecoration: @Composable (@Composable () -> Unit) -> Unit = { innerTextField ->
                             Box(
                                 Modifier
-                                    .padding(4.dp)
-                                    .size(56.dp)
-                                    .clip(RoundedCornerShape(8.dp))
-                                    .background(colors.primary.copy(alpha = 0.1f)),
-                                contentAlignment = Alignment.Center
+                                    .fillMaxSize()
+                                    .heightIn(min = 48.dp),
+                                contentAlignment = Alignment.CenterEnd
                             ) {
-                                Icon(
-                                    Icons.Default.Check,
-                                    stringResource(R.string.column_set_complete)
-                                )
+                                innerTextField()
                             }
                         }
-                        for (set in setGroup.sets) {
+                        setGroup.sets.forEachIndexed { index, set ->
                             key(set.workoutSetId) {
-                                val dismissState = rememberDismissState()
-                                LaunchedEffect(dismissState.currentValue) {
-                                    if (dismissState.currentValue != DismissValue.Default) {
-                                        viewModel.deleteSet(set)
-                                        dismissState.snapTo(DismissValue.Default)
+                                val dismissState = rememberDismissState(
+                                    confirmValueChange = { value ->
+                                        if (value != DismissValue.Default) {
+                                            // Ask for confirmation before removing the set via swipe.
+                                            setPendingDeletion = set
+                                            pendingSetGroup = setGroup
+                                            false
+                                        } else {
+                                            true
+                                        }
                                     }
-                                }
+                                )
                                 SwipeToDismiss(
                                     state = dismissState,
                                     background = { SwipeToDeleteBackground(dismissState) },
                                 ) {
-                                    Surface {
-                                        Row(
-                                            Modifier.padding(horizontal = 4.dp)
-                                        ) {
-                                            val textFieldStyle = typography.body1.copy(
-                                                textAlign = TextAlign.Center,
-                                                color = colors.onSurface
+                                    Row(
+                                        Modifier
+                                            .fillMaxWidth()
+                                            .padding(horizontal = 16.dp),
+                                        verticalAlignment = Alignment.CenterVertically
+                                    ) {
+                                        if (exercise?.logReps == true) {
+                                            val (reps, setReps) = remember { mutableStateOf(set.reps.toStringOrBlank()) }
+                                            LaunchedEffect(reps) {
+                                                val repsInt = reps.toIntOrNull()
+                                                viewModel.updateReps(set, repsInt)
+                                            }
+                                            AutoSelectTextField(
+                                                modifier = Modifier
+                                                    .weight(1f)
+                                                    .padding(horizontal = 8.dp)
+                                                    .heightIn(min = 48.dp),
+                                                value = reps,
+                                                onValueChange = {
+                                                    if (it.matches(RegexPatterns.integer))
+                                                        setReps(it)
+                                                },
+                                                textStyle = textFieldStyle,
+                                                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                                                singleLine = true,
+                                                cursorColor = colors.onSurface,
+                                                decorationBox = cellDecoration,
                                             )
-                                            val decorationBox: @Composable (@Composable () -> Unit) -> Unit =
-                                                { innerTextField ->
-                                                    Surface(
-                                                        color = colors.onSurface.copy(alpha = 0.1f),
-                                                        shape = RoundedCornerShape(8.dp),
-                                                    ) {
-                                                        Box(
-                                                            Modifier
-                                                                .padding(horizontal = 4.dp)
-                                                                .height(56.dp),
-                                                            contentAlignment = Alignment.Center
-                                                        ) {
-                                                            innerTextField()
-                                                        }
-                                                    }
-                                                }
-                                            if (exercise?.logReps == true) {
-                                                val (reps, setReps) = remember { mutableStateOf(set.reps.toStringOrBlank()) }
-                                                LaunchedEffect(reps) {
-                                                    val repsInt = reps.toIntOrNull()
-                                                    viewModel.updateReps(set, repsInt)
-                                                }
-                                                AutoSelectTextField(
-                                                    modifier = Modifier
-                                                        .weight(1f)
-                                                        .padding(4.dp),
-                                                    value = reps,
-                                                    onValueChange = {
-                                                        if (it.matches(RegexPatterns.integer))
-                                                            setReps(it)
-                                                    },
-                                                    textStyle = textFieldStyle,
-                                                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                                                    singleLine = true,
-                                                    cursorColor = colors.onSurface,
-                                                    decorationBox = decorationBox,
+                                        }
+                                        if (exercise?.logWeight == true) {
+                                            val (weight, setWeight) = remember {
+                                                mutableStateOf(
+                                                    set.weight.formatSimple()
                                                 )
                                             }
-                                            if (exercise?.logWeight == true) {
-                                                val (weight, setWeight) = remember {
-                                                    mutableStateOf(
-                                                        set.weight.formatSimple()
-                                                    )
-                                                }
-                                                LaunchedEffect(weight) {
-                                                    val weightDouble = weight.toDoubleOrNull()
-                                                    viewModel.updateWeight(set, weightDouble)
-                                                }
-                                                AutoSelectTextField(
-                                                    modifier = Modifier
-                                                        .weight(1f)
-                                                        .padding(4.dp),
-                                                    value = weight,
-                                                    onValueChange = {
-                                                        if (it.matches(RegexPatterns.float))
-                                                            setWeight(it)
-                                                    },
-                                                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                                                    singleLine = true,
-                                                    textStyle = textFieldStyle,
-                                                    cursorColor = colors.onSurface,
-                                                    decorationBox = decorationBox
+                                            LaunchedEffect(weight) {
+                                                val weightDouble = weight.toDoubleOrNull()
+                                                viewModel.updateWeight(set, weightDouble)
+                                            }
+                                            AutoSelectTextField(
+                                                modifier = Modifier
+                                                    .weight(1f)
+                                                    .padding(horizontal = 8.dp)
+                                                    .heightIn(min = 48.dp),
+                                                value = weight,
+                                                onValueChange = {
+                                                    if (it.matches(RegexPatterns.float))
+                                                        setWeight(it)
+                                                },
+                                                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                                                singleLine = true,
+                                                textStyle = textFieldStyle,
+                                                cursorColor = colors.onSurface,
+                                                decorationBox = cellDecoration
+                                            )
+                                        }
+                                        if (exercise?.logTime == true) {
+                                            val (time, setTime) = remember { mutableStateOf(set.time.toStringOrBlank()) }
+                                            LaunchedEffect(time) {
+                                                val timeInt = time.toIntOrNull()
+                                                viewModel.updateTime(set, timeInt)
+                                            }
+                                            AutoSelectTextField(
+                                                modifier = Modifier
+                                                    .weight(1f)
+                                                    .padding(horizontal = 8.dp)
+                                                    .heightIn(min = 48.dp),
+                                                value = time,
+                                                onValueChange = {
+                                                    if (it.matches(RegexPatterns.duration))
+                                                        setTime(it)
+                                                },
+                                                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                                                singleLine = true,
+                                                textStyle = textFieldStyle,
+                                                visualTransformation = durationVisualTransformation,
+                                                cursorColor = colors.onSurface,
+                                                decorationBox = cellDecoration
+                                            )
+                                        }
+                                        if (exercise?.logDistance == true) {
+                                            val (distance, setDistance) = remember {
+                                                mutableStateOf(
+                                                    set.distance.formatSimple()
                                                 )
                                             }
-                                            if (exercise?.logTime == true) {
-                                                val (time, setTime) = remember { mutableStateOf(set.time.toStringOrBlank()) }
-                                                LaunchedEffect(time) {
-                                                    val timeInt = time.toIntOrNull()
-                                                    viewModel.updateTime(set, timeInt)
-                                                }
-                                                AutoSelectTextField(
-                                                    modifier = Modifier
-                                                        .weight(1f)
-                                                        .padding(4.dp),
-                                                    value = time,
-                                                    onValueChange = {
-                                                        if (it.matches(RegexPatterns.duration))
-                                                            setTime(it)
-                                                    },
-                                                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                                                    singleLine = true,
-                                                    textStyle = textFieldStyle,
-                                                    visualTransformation = durationVisualTransformation,
-                                                    cursorColor = colors.onSurface,
-                                                    decorationBox = decorationBox
-                                                )
+                                            LaunchedEffect(distance) {
+                                                val distanceDouble = distance.toDoubleOrNull()
+                                                viewModel.updateDistance(set, distanceDouble)
                                             }
-                                            if (exercise?.logDistance == true) {
-                                                val (distance, setDistance) = remember {
-                                                    mutableStateOf(
-                                                        set.distance.formatSimple()
-                                                    )
-                                                }
-                                                LaunchedEffect(distance) {
-                                                    val distanceDouble = distance.toDoubleOrNull()
-                                                    viewModel.updateDistance(set, distanceDouble)
-                                                }
-                                                AutoSelectTextField(
-                                                    modifier = Modifier
-                                                        .weight(1f)
-                                                        .padding(4.dp),
-                                                    value = distance,
+                                            AutoSelectTextField(
+                                                modifier = Modifier
+                                                    .weight(1f)
+                                                    .padding(horizontal = 8.dp)
+                                                    .heightIn(min = 48.dp),
+                                                value = distance,
+                                                onValueChange = {
+                                                    if (it.matches(RegexPatterns.float))
+                                                        setDistance(it)
+                                                },
+                                                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                                                singleLine = true,
+                                                textStyle = textFieldStyle,
+                                                cursorColor = colors.onSurface,
+                                                decorationBox = cellDecoration
+                                            )
+                                        }
+                                        val toggleColor by animateColorAsState(
+                                            targetValue = if (set.complete) colors.secondary else colors.onSurface.copy(
+                                                alpha = 0.08f
+                                            ),
+                                            label = "SetCompleteToggle"
+                                        )
+                                        Box(
+                                            Modifier
+                                                .padding(start = 8.dp)
+                                                .widthIn(min = 48.dp)
+                                                .heightIn(min = 48.dp)
+                                                .clip(RoundedCornerShape(12.dp))
+                                                .toggleable(
+                                                    value = set.complete,
                                                     onValueChange = {
-                                                        if (it.matches(RegexPatterns.float))
-                                                            setDistance(it)
+                                                        viewModel.updateChecked(set, it)
                                                     },
-                                                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                                                    singleLine = true,
-                                                    textStyle = textFieldStyle,
-                                                    cursorColor = colors.onSurface,
-                                                    decorationBox = decorationBox
                                                 )
-                                            }
-                                            Box(
-                                                Modifier
-                                                    .padding(4.dp)
-                                                    .size(56.dp)
-                                                    .clip(RoundedCornerShape(8.dp))
-                                                    .toggleable(
-                                                        value = set.complete,
-                                                        onValueChange = {
-                                                            viewModel.updateChecked(set, it)
-                                                        },
-                                                    )
-                                                    .background(
-                                                        animateColorAsState(
-                                                            if (set.complete) colors.secondary else colors.onSurface.copy(
-                                                                alpha = 0.1f
-                                                            )
-                                                        ).value
-                                                    ),
-                                                contentAlignment = Alignment.Center
+                                                .background(toggleColor),
+                                            contentAlignment = Alignment.Center
+                                        ) {
+                                            androidx.compose.animation.AnimatedVisibility(
+                                                visible = set.complete,
+                                                enter = fadeIn(),
+                                                exit = fadeOut()
                                             ) {
-                                                androidx.compose.animation.AnimatedVisibility(
-                                                    visible = set.complete,
-                                                    enter = fadeIn(),
-                                                    exit = fadeOut()
-                                                ) {
-                                                    Icon(
-                                                        Icons.Default.Check,
-                                                        stringResource(R.string.column_set_complete),
-                                                        tint = colors.onSecondary
-                                                    )
-                                                }
+                                                Icon(
+                                                    Icons.Default.Check,
+                                                    stringResource(R.string.column_set_complete),
+                                                    tint = colors.onSecondary
+                                                )
                                             }
                                         }
                                     }
                                 }
+                            }
+                            if (index < setGroup.sets.lastIndex) {
+                                Divider(Modifier.padding(horizontal = 16.dp))
                             }
                         }
                     }
                     TextButton(
                         modifier = Modifier
-                            .fillMaxWidth()
-                            .height(64.dp),
+                            .align(Alignment.End)
+                            .padding(horizontal = 16.dp, vertical = 8.dp)
+                            .defaultMinSize(minHeight = 48.dp),
                         onClick = { viewModel.addSet(setGroup) },
                     ) {
-                        Icon(Icons.Default.Add, null)
-                        Spacer(Modifier.width(12.dp))
+                        Icon(Icons.Default.Add, stringResource(R.string.btn_add_set))
+                        Spacer(Modifier.width(8.dp))
                         Text(stringResource(R.string.btn_add_set))
                     }
                 }
@@ -532,46 +596,76 @@ private fun WorkoutInProgressContent(
         }
 
         item {
-            Button(
+            Column(
                 modifier = Modifier
-                    .padding(top = 24.dp, start = 24.dp, end = 24.dp)
                     .fillMaxWidth()
-                    .height(128.dp),
-                shape = RoundedCornerShape(24.dp),
-                onClick = navToExercisePicker
-            ) {
-                Icon(Icons.Default.Add, null)
-                Spacer(Modifier.width(12.dp))
-                Text(stringResource(R.string.btn_add_exercise))
-            }
-
-            Row(
-                Modifier
-                    .fillMaxWidth()
-                    .padding(24.dp),
-                horizontalArrangement = Arrangement.Center,
+                    .padding(horizontal = 24.dp, vertical = 16.dp)
             ) {
                 OutlinedButton(
-                    modifier = Modifier.height(40.dp),
-                    shape = RoundedCornerShape(percent = 100),
-                    onClick = { showCancelWorkoutDialog = true },
-                ) {
-                    Text(stringResource(R.string.btn_discard_workout))
-                }
-                Spacer(Modifier.width(16.dp))
-                Button(
                     modifier = Modifier
-                        .weight(1f)
-                        .height(40.dp),
-                    shape = RoundedCornerShape(percent = 100),
-                    onClick = { showFinishWorkoutDialog = true }
+                        .fillMaxWidth()
+                        .height(56.dp),
+                    shape = RoundedCornerShape(16.dp),
+                    onClick = navToExercisePicker
                 ) {
-                    Text(stringResource(R.string.btn_finish_workout))
+                    Icon(Icons.Default.Add, stringResource(R.string.btn_add_exercise))
+                    Spacer(Modifier.width(8.dp))
+                    Text(stringResource(R.string.btn_add_exercise))
+                }
+
+                Spacer(Modifier.height(24.dp))
+
+                Row(
+                    Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(16.dp),
+                ) {
+                    OutlinedButton(
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(48.dp),
+                        shape = RoundedCornerShape(percent = 100),
+                        onClick = { showCancelWorkoutDialog = true },
+                    ) {
+                        Text(stringResource(R.string.btn_discard_workout))
+                    }
+                    Button(
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(48.dp),
+                        shape = RoundedCornerShape(percent = 100),
+                        onClick = { showFinishWorkoutDialog = true }
+                    ) {
+                        Text(stringResource(R.string.btn_finish_workout))
+                    }
                 }
             }
         }
     }
 }
+
+
+@Composable
+private fun ConfirmDeleteSetDialog(
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.dialog_title_delete_set)) },
+        text = { Text(stringResource(R.string.dialog_body_delete_set)) },
+        confirmButton = {
+            Button(onClick = onConfirm) {
+                Text(stringResource(R.string.dialog_confirm_delete_set))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.btn_cancel))
+            }
+        }
+    )
+}
+
 
 @Composable
 private fun CancelWorkoutDialog(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,6 +23,7 @@
     <string name="btn_add_set">Add Set</string>
     <string name="column_reps">Reps</string>
     <string name="column_weight">Weight</string>
+    <string name="column_weight_with_unit">Weight (kg)</string>
     <string name="column_time">Time</string>
     <string name="column_distance">Distance</string>
     <string name="column_set_complete">Set Complete</string>
@@ -97,6 +98,11 @@
     <string name="dialog_title_discard_workout">Discard Workout?</string>
     <string name="dialog_title_finish_workout">Finish Workout?</string>
     <string name="dialog_confirm_finish_workout">Finish</string>
+    <string name="dialog_title_delete_set">Remove set?</string>
+    <string name="dialog_body_delete_set">This set will be deleted from the workout.</string>
+    <string name="dialog_confirm_delete_set">Remove</string>
+    <string name="snackbar_set_removed">Set removed</string>
+    <string name="action_undo">Undo</string>
     <string name="chart_workout_duration">Workout duration</string>
     <string name="chart_insufficient_data">Not enough data.</string>
     <string name="screen_view_workout">View Workout</string>


### PR DESCRIPTION
## Summary
- compacted the workout-in-progress layout with tighter headers, right-aligned numeric fields, and a lightweight add-set control
- reformatted the routine banner and timer for better hierarchy while keeping names single-line with ellipsis and unit labeling
- added a confirmation dialog and undo snackbar for swipe-to-delete set actions via new restore logic

## Testing
- ./gradlew :app:lintDebug *(fails: SDK location not configured in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dabdfdb9f08324a4e626914806ec0f