### PR TITLE
Fix missing Compose key import in WorkoutInProgress screen

### DIFF
--- a/app/src/main/java/com/noahjutz/gymroutines/ui/workout/in_progress/WorkoutInProgress.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/workout/in_progress/WorkoutInProgress.kt
@@ -76,6 +76,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope


### PR DESCRIPTION
## Summary
- import the androidx.compose.runtime.key helper used in WorkoutInProgress to resolve build errors

## Testing
- Unable to run `./gradlew assembleDebug` (Android SDK is not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68dac52e7dfc8324aaa5becdda5cbab3