### PR TITLE
Fix confirm button background parameter

### DIFF
--- a/app/src/main/java/com/noahjutz/gymroutines/ui/workout/in_progress/WorkoutInProgress.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/workout/in_progress/WorkoutInProgress.kt
@@ -46,6 +46,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.AlertDialog
 import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Card
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.DismissValue
@@ -85,6 +86,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
@@ -189,7 +191,8 @@ private fun WorkoutInProgressContent(
         onDismiss = { showCancelWorkoutDialog = false },
         cancelWorkout = {
             viewModel.cancelWorkout(popBackStack)
-        }
+        },
+        confirmButtonBackground = colors.error,
     )
 
     val coroutineScope = rememberCoroutineScope()
@@ -221,7 +224,8 @@ private fun WorkoutInProgressContent(
                 }
                 setPendingDeletion = null
                 pendingSetGroup = null
-            }
+            },
+            confirmButtonBackground = colors.error,
         )
     }
 
@@ -649,13 +653,21 @@ private fun WorkoutInProgressContent(
 private fun ConfirmDeleteSetDialog(
     onDismiss: () -> Unit,
     onConfirm: () -> Unit,
+    confirmButtonBackground: Color? = null,
 ) {
+    val confirmButtonColors = confirmButtonBackground?.let { background ->
+        ButtonDefaults.buttonColors(containerColor = background)
+    } ?: ButtonDefaults.buttonColors()
+
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text(stringResource(R.string.dialog_title_delete_set)) },
         text = { Text(stringResource(R.string.dialog_body_delete_set)) },
         confirmButton = {
-            Button(onClick = onConfirm) {
+            Button(
+                onClick = onConfirm,
+                colors = confirmButtonColors,
+            ) {
                 Text(stringResource(R.string.dialog_confirm_delete_set))
             }
         },
@@ -672,11 +684,23 @@ private fun ConfirmDeleteSetDialog(
 private fun CancelWorkoutDialog(
     onDismiss: () -> Unit,
     cancelWorkout: () -> Unit,
+    confirmButtonBackground: Color? = null,
 ) {
+    val confirmButtonColors = confirmButtonBackground?.let { background ->
+        ButtonDefaults.buttonColors(containerColor = background)
+    } ?: ButtonDefaults.buttonColors()
+
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text(stringResource(R.string.dialog_title_discard_workout)) },
-        confirmButton = { Button(onClick = cancelWorkout) { Text(stringResource(R.string.btn_delete)) } },
+        confirmButton = {
+            Button(
+                onClick = cancelWorkout,
+                colors = confirmButtonColors,
+            ) {
+                Text(stringResource(R.string.btn_delete))
+            }
+        },
         dismissButton = { TextButton(onClick = onDismiss) { Text(stringResource(R.string.btn_cancel)) } },
     )
 }


### PR DESCRIPTION
## Summary
- allow passing an optional `confirmButtonBackground` color into the workout confirmation dialogs
- apply the destructive red color to the cancel workout and delete set dialogs while reusing the shared coloring logic

## Testing
- not run (Android SDK not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68dac73889608324be4420c14ac16130