### PR TITLE
Fix namespace mismatch preventing debug build

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -86,7 +86,7 @@ android {
             )
         )
     }
-    namespace = "com.boekenbox.gymroutines"
+    namespace = "com.noahjutz.gymroutines"
 }
 
 dependencies {


### PR DESCRIPTION
## Summary
- align the app namespace with the existing source packages so that R references resolve

## Testing
- ./gradlew assembleDebug --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e509f4b5b483249959a3ef5dc04482