### PR TITLE
Add confirmation before deleting routine sets

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,6 +57,7 @@
     <string name="label_exercise_notes">Notes</string>
     <string name="btn_more">More</string>
     <string name="btn_delete">Delete</string>
+    <string name="dialog_item_set">this set</string>
     <string name="btn_select_option">Select</string>
     <string name="sheet_workout_in_progress">Workout in progress</string>
     <string name="btn_expand">Expand</string>


### PR DESCRIPTION
## Summary
- add a confirmation dialog when swiping to delete routine sets so it matches exercise deletion
- introduce a reusable string resource for the dialog body text

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e510c65dc08324a7da273add49c90a