### PR TITLE
Add consistent horizontal padding to routine screens

### DIFF
--- a/app/src/main/java/com/noahjutz/gymroutines/ui/routines/editor/RoutineEditor.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/routines/editor/RoutineEditor.kt
@@ -153,8 +153,10 @@ private fun RoutineEditorContent(
     navToExercisePicker: () -> Unit
 ) {
     LazyColumn(
-        Modifier.fillMaxHeight(),
-        contentPadding = PaddingValues(bottom = 70.dp)
+        modifier = Modifier
+            .fillMaxHeight()
+            .padding(horizontal = 24.dp),
+        contentPadding = PaddingValues(top = 16.dp, bottom = 70.dp)
     ) {
 
         item {
@@ -164,9 +166,7 @@ private fun RoutineEditorContent(
             }
             val (nameLineCount, setNameLineCount) = remember { mutableStateOf(0) }
             BasicTextField(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 16.dp, start = 30.dp, end = 30.dp),
+                modifier = Modifier.fillMaxWidth(),
                 value = name,
                 onValueChange = setName,
                 onTextLayout = { setNameLineCount(it.lineCount) },

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/workout/in_progress/WorkoutInProgress.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/workout/in_progress/WorkoutInProgress.kt
@@ -169,12 +169,16 @@ private fun WorkoutInProgressContent(
         }
     )
 
-    LazyColumn(Modifier.fillMaxHeight()) {
+    LazyColumn(
+        Modifier
+            .fillMaxHeight()
+            .padding(horizontal = 24.dp)
+    ) {
         item {
             Surface(
                 Modifier
                     .fillMaxWidth()
-                    .padding(top = 24.dp, start = 24.dp, end = 24.dp),
+                    .padding(top = 24.dp),
                 color = colors.onSurface.copy(alpha = 0.1f),
                 shape = RoundedCornerShape(24.dp)
             ) {
@@ -189,7 +193,7 @@ private fun WorkoutInProgressContent(
                 workout.workout.duration.pretty(),
                 Modifier
                     .fillMaxWidth()
-                    .padding(top = 24.dp, start = 24.dp, end = 24.dp),
+                    .padding(top = 24.dp),
                 style = typography.h4.copy(textAlign = TextAlign.Center)
             )
         }
@@ -534,7 +538,7 @@ private fun WorkoutInProgressContent(
         item {
             Button(
                 modifier = Modifier
-                    .padding(top = 24.dp, start = 24.dp, end = 24.dp)
+                    .padding(top = 24.dp)
                     .fillMaxWidth()
                     .height(128.dp),
                 shape = RoundedCornerShape(24.dp),
@@ -548,7 +552,7 @@ private fun WorkoutInProgressContent(
             Row(
                 Modifier
                     .fillMaxWidth()
-                    .padding(24.dp),
+                    .padding(vertical = 24.dp),
                 horizontalArrangement = Arrangement.Center,
             ) {
                 OutlinedButton(

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/workout/viewer/WorkoutViewer.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/workout/viewer/WorkoutViewer.kt
@@ -72,23 +72,23 @@ fun WorkoutViewer(
 @ExperimentalTime
 @Composable
 fun WorkoutViewerContent(workout: WorkoutWithSetGroups, viewModel: WorkoutViewerViewModel) {
-    LazyColumn {
+    LazyColumn(Modifier.fillMaxSize().padding(horizontal = 24.dp)) {
         item {
             val routineName by viewModel.routineName.collectAsState(initial = "")
             Spacer(Modifier.height(24.dp))
             Text(
                 text = routineName.takeIf { it.isNotBlank() }
                     ?: stringResource(R.string.unnamed_routine),
-                modifier = Modifier.padding(horizontal = 24.dp),
+                modifier = Modifier.fillMaxWidth(),
                 style = typography.h4,
             )
             Text(
                 text = workout.workout.endTime.formatSimple(),
-                modifier = Modifier.padding(horizontal = 24.dp),
+                modifier = Modifier.fillMaxWidth(),
             )
             Text(
                 text = workout.workout.duration.pretty(),
-                modifier = Modifier.padding(horizontal = 24.dp),
+                modifier = Modifier.fillMaxWidth(),
             )
         }
 


### PR DESCRIPTION
## Summary
- add horizontal padding around the routine editor list so cards no longer touch the edges
- mirror the same outer padding on the workout viewer and in-progress routine screens for consistent spacing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5158ab7648324a45b282156c92886