### PR TITLE
Fix invalid return statement in WorkoutInsightsViewModel

### DIFF
--- a/app/src/main/java/com/noahjutz/gymroutines/ui/workout/insights/WorkoutInsightsViewModel.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/workout/insights/WorkoutInsightsViewModel.kt
@@ -139,8 +139,6 @@ class WorkoutInsightsViewModel(
                 prefs[AppPrefs.InsightsSelectedExercise.key] = exerciseId
             }
         }
-
-        return events.sortedByDescending { it.occurredAt } to perSession.mapValues { it.value.sortedByDescending { event -> event.occurredAt } }
     }
 
     private fun buildDurationChart(sessions: List<SessionComputation>): WorkoutDurationChartData? {


### PR DESCRIPTION
## Summary
- remove the erroneous return from `WorkoutInsightsViewModel.onExerciseSelected` that referenced undefined variables and broke compilation

## Testing
- ❌ ./gradlew assemble (fails: SDK location not found in environment)

------
https://chatgpt.com/codex/tasks/task_e_68e523f4d56c8324b2086eca61a11b1b