### PR TITLE
Fix missing brace in WorkoutInsightsViewModel

### DIFF
--- a/app/src/main/java/com/noahjutz/gymroutines/ui/workout/insights/WorkoutInsightsViewModel.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/workout/insights/WorkoutInsightsViewModel.kt
@@ -261,6 +261,7 @@ class WorkoutInsightsViewModel(
                 workoutsCount = data.second,
                 rollingAverage = rollingAverage
             )
+        }
         val trimmed = points.takeLast(12)
         val comparisonPercent = if (trimmed.size < 2) {
             null


### PR DESCRIPTION
## Summary
- close the weekly volume map lambda in WorkoutInsightsViewModel so the file compiles

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: Android SDK not configured in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5251ec0ec8324b4f68db671f4e8bc