### PR TITLE
Fix insights chart crash and wire up PR history screen

### DIFF
--- a/app/src/main/java/com/noahjutz/gymroutines/ui/NavGraph.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/NavGraph.kt
@@ -51,6 +51,7 @@ import com.noahjutz.gymroutines.ui.settings.data.DataSettings
 import com.noahjutz.gymroutines.ui.settings.general.GeneralSettings
 import com.noahjutz.gymroutines.ui.workout.completed.WorkoutCompleted
 import com.noahjutz.gymroutines.ui.workout.in_progress.WorkoutInProgress
+import com.noahjutz.gymroutines.ui.workout.insights.PrHistoryScreen
 import com.noahjutz.gymroutines.ui.workout.insights.WorkoutInsights
 import com.noahjutz.gymroutines.ui.workout.viewer.WorkoutViewer
 import kotlin.time.ExperimentalTime
@@ -65,6 +66,7 @@ enum class Screen {
     exercisePicker,
     workoutInProgress,
     workoutViewer,
+    prHistory,
     settings,
     appearanceSettings,
     dataSettings,
@@ -96,7 +98,8 @@ fun NavGraph(
             composable(Screen.insights.name) {
                 WorkoutInsights(
                     navToWorkout = { workoutId -> navController.navigate("${Screen.workoutViewer}/$workoutId") },
-                    navToSettings = { navController.navigate(Screen.settings.name) }
+                    navToSettings = { navController.navigate(Screen.settings.name) },
+                    navToPrHistory = { navController.navigate(Screen.prHistory.name) }
                 )
             }
             composable(
@@ -107,6 +110,12 @@ fun NavGraph(
                 WorkoutViewer(
                     workoutId = workoutId,
                     popBackStack = { navController.popBackStack() },
+                )
+            }
+            composable(Screen.prHistory.name) {
+                PrHistoryScreen(
+                    popBackStack = { navController.popBackStack() },
+                    navToWorkout = { workoutId -> navController.navigate("${Screen.workoutViewer}/$workoutId") }
                 )
             }
             composable(Screen.routineList.name) {

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/components/SimpleLineChart.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/components/SimpleLineChart.kt
@@ -22,20 +22,24 @@ fun SimpleLineChart(
     check(data.isNotEmpty()) { "data passed to SimpleLineChart must not be empty" }
 
     Canvas(modifier) {
-        val minX = minOf(data.minOf { it.first }, secondaryData.minOf { it.first })
-        val maxX = maxOf(data.maxOf { it.first }, secondaryData.maxOf { it.first })
-        val minY = minOf(data.minOf { it.second }, secondaryData.minOf { it.second })
-        val maxY = maxOf(data.maxOf { it.second }, secondaryData.maxOf { it.second })
+        val combined = if (secondaryData.isEmpty()) data else data + secondaryData
+        val minX = combined.minOf { it.first }
+        val maxX = combined.maxOf { it.first }
+        val minY = combined.minOf { it.second }
+        val maxY = combined.maxOf { it.second }
+
+        val xRange = (maxX - minX).takeIf { it != 0f } ?: 1f
+        val yRange = (maxY - minY).takeIf { it != 0f } ?: 1f
 
         val offsets = data.map { (x, y) ->
-            val xAdjusted = ((x - minX) / (maxX - minX)) * size.width
-            val yAdjusted = (1 - ((y - minY) / (maxY - minY))) * size.height
+            val xAdjusted = ((x - minX) / xRange) * size.width
+            val yAdjusted = (1 - ((y - minY) / yRange)) * size.height
             Offset(xAdjusted, yAdjusted)
         }
 
         val secondaryOffsets = secondaryData.map { (x, y) ->
-            val xAdjusted = ((x - minX) / (maxX - minX)) * size.width
-            val yAdjusted = (1 - ((y - minY) / (maxY - minY))) * size.height
+            val xAdjusted = ((x - minX) / xRange) * size.width
+            val yAdjusted = (1 - ((y - minY) / yRange)) * size.height
             Offset(xAdjusted, yAdjusted)
         }
 

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/workout/insights/PrHistoryScreen.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/workout/insights/PrHistoryScreen.kt
@@ -1,0 +1,87 @@
+package com.noahjutz.gymroutines.ui.workout.insights
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.noahjutz.gymroutines.R
+import com.noahjutz.gymroutines.ui.components.TopBar
+import org.koin.androidx.compose.getViewModel
+
+@Composable
+fun PrHistoryScreen(
+    viewModel: WorkoutInsightsViewModel = getViewModel(),
+    popBackStack: () -> Unit,
+    navToWorkout: (Int) -> Unit,
+) {
+    val state by viewModel.uiState.collectAsState()
+    val prs = state.prs
+
+    Scaffold(
+        topBar = {
+            TopBar(
+                title = stringResource(R.string.insights_prs_history_title),
+                navigationIcon = {
+                    IconButton(onClick = popBackStack) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = stringResource(R.string.btn_pop_back))
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        if (prs.isEmpty()) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(text = stringResource(R.string.insights_prs_empty))
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding),
+                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                items(prs, key = { it.id }) { pr ->
+                    Surface(
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = MaterialTheme.shapes.medium,
+                        elevation = 2.dp
+                    ) {
+                        PrRow(
+                            pr = pr,
+                            onClick = { navToWorkout(pr.workoutId) },
+                            modifier = Modifier
+                                .clickable { navToWorkout(pr.workoutId) }
+                                .padding(horizontal = 16.dp, vertical = 12.dp)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/workout/insights/WorkoutInsights.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/workout/insights/WorkoutInsights.kt
@@ -336,9 +336,9 @@ private fun DeltaValue(value: Double, suffix: String, showDecimals: Boolean = tr
 }
 
 @Composable
-private fun PrRow(pr: PrEventUi, onClick: () -> Unit) {
+fun PrRow(pr: PrEventUi, onClick: () -> Unit, modifier: Modifier = Modifier) {
     Row(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/workout/insights/WorkoutInsightsViewModel.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/workout/insights/WorkoutInsightsViewModel.kt
@@ -113,7 +113,7 @@ class WorkoutInsightsViewModel(
                     lastSessionSummary = summary,
                     weeklyVolume = weeklyVolume,
                     sessionComparison = sessionComparison,
-                    prs = prComputation.first.take(5),
+                    prs = prComputation.first,
                     exerciseProgress = exerciseProgress,
                     consistency = consistency,
                     routineUtilization = routineUtilization,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -109,6 +109,7 @@
     <string name="insights_session_comparison_against">Compared with %1$s</string>
     <string name="insights_session_comparison_volume_delta">Session volume Δ %1$s</string>
     <string name="insights_prs_title">Personal records</string>
+    <string name="insights_prs_history_title">PR history</string>
     <string name="insights_prs_view_all">View all PRs</string>
     <string name="insights_prs_empty">No PRs yet. Keep training!</string>
     <string name="insights_weekly_volume_title">Weekly volume</string>


### PR DESCRIPTION
## Summary
- guard the shared line chart against empty secondary data so the insights screen no longer crashes when more cards compose
- surface a dedicated PR history screen and reuse the preview row so "View all PRs" shows the full list
- add navigation wiring and copy updates to reach the new screen from insights

## Testing
- ./gradlew :app:assembleDebug *(fails: missing Android SDK in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e52da0d2b8832492513201d6cc61ac