### PR TITLE
Refine personal record tracking and add deterministic streak utilities

### DIFF
--- a/app/src/main/java/com/noahjutz/gymroutines/util/DateUtil.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/util/DateUtil.kt
@@ -1,7 +1,9 @@
 package com.noahjutz.gymroutines.util
 
 import java.text.DateFormat
-import java.util.*
+import java.time.LocalDate
+import java.time.ZoneId
+import java.util.Date
 import kotlin.time.Duration
 
 fun Date.formatSimple(): String {
@@ -9,3 +11,28 @@ fun Date.formatSimple(): String {
 }
 
 fun Duration.pretty(): String = toComponents { h, m, _, _ -> "${h}h ${m}min" }
+
+val List<Date>.currentDailyStreak: Int
+    get() = currentDailyStreakInternal()
+
+internal fun List<Date>.currentDailyStreakInternal(now: Date = Date()): Int {
+    if (isEmpty()) return 0
+    val zone = ZoneId.systemDefault()
+    val today = now.toInstant().atZone(zone).toLocalDate()
+    val days = map { it.toInstant().atZone(zone).toLocalDate() }
+        .filter { !it.isAfter(today) }
+        .toSet()
+
+    if (!days.contains(today)) {
+        return 0
+    }
+
+    var streak = 0
+    var current = today
+    while (days.contains(current)) {
+        streak += 1
+        current = current.minusDays(1)
+    }
+
+    return streak
+}

--- a/app/src/test/java/com/noahjutz/gymroutines/DateUtilTest.kt
+++ b/app/src/test/java/com/noahjutz/gymroutines/DateUtilTest.kt
@@ -1,10 +1,11 @@
 package com.noahjutz.splitfit
 
-import com.noahjutz.gymroutines.util.currentDailyStreak
-import java.util.*
+import com.noahjutz.gymroutines.util.currentDailyStreakInternal
+import java.util.Calendar
+import java.util.Date
 import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.hours
 import kotlin.time.ExperimentalTime
-import kotlin.time.hours
 import org.junit.Test
 
 @ExperimentalTime
@@ -14,102 +15,103 @@ class DateUtilTest {
 
     private val dates5Streak = listOf(
         now,
-        Date((now.time - 24.hours.absoluteValue.inMilliseconds).toLong()),
-        Date((now.time - 48.hours.absoluteValue.inMilliseconds).toLong()),
-        Date((now.time - 72.hours.absoluteValue.inMilliseconds).toLong()),
-        Date((now.time - 96.hours.absoluteValue.inMilliseconds).toLong()),
+        Date((now.time - 24.hours.absoluteValue.inWholeMilliseconds).toLong()),
+        Date((now.time - 48.hours.absoluteValue.inWholeMilliseconds).toLong()),
+        Date((now.time - 72.hours.absoluteValue.inWholeMilliseconds).toLong()),
+        Date((now.time - 96.hours.absoluteValue.inWholeMilliseconds).toLong()),
     )
 
     private val dates3StreakInterrupted = listOf(
         now,
-        Date((now.time - 24.hours.absoluteValue.inMilliseconds).toLong()),
-        Date((now.time - 48.hours.absoluteValue.inMilliseconds).toLong()),
-        Date((now.time - 96.hours.absoluteValue.inMilliseconds).toLong()),
+        Date((now.time - 24.hours.absoluteValue.inWholeMilliseconds).toLong()),
+        Date((now.time - 48.hours.absoluteValue.inWholeMilliseconds).toLong()),
+        Date((now.time - 96.hours.absoluteValue.inWholeMilliseconds).toLong()),
     )
 
     private val datesNoStreak = listOf(
-        Date((now.time - 24.hours.absoluteValue.inMilliseconds).toLong()),
-        Date((now.time - 48.hours.absoluteValue.inMilliseconds).toLong()),
-        Date((now.time - 72.hours.absoluteValue.inMilliseconds).toLong()),
-        Date((now.time - 96.hours.absoluteValue.inMilliseconds).toLong()),
+        Date((now.time - 24.hours.absoluteValue.inWholeMilliseconds).toLong()),
+        Date((now.time - 48.hours.absoluteValue.inWholeMilliseconds).toLong()),
+        Date((now.time - 72.hours.absoluteValue.inWholeMilliseconds).toLong()),
+        Date((now.time - 96.hours.absoluteValue.inWholeMilliseconds).toLong()),
     )
 
     private val dates5StreakMultipleADay = listOf(
         now,
-        Date((now.time - 24.hours.absoluteValue.inMilliseconds).toLong()),
-        Date((now.time - 24.hours.absoluteValue.inMilliseconds).toLong()),
-        Date((now.time - 48.hours.absoluteValue.inMilliseconds).toLong()),
-        Date((now.time - 48.hours.absoluteValue.inMilliseconds).toLong()),
-        Date((now.time - 72.hours.absoluteValue.inMilliseconds).toLong()),
-        Date((now.time - 96.hours.absoluteValue.inMilliseconds).toLong()),
-        Date((now.time - 96.hours.absoluteValue.inMilliseconds).toLong()),
-        Date((now.time - 96.hours.absoluteValue.inMilliseconds).toLong()),
-        Date((now.time - 96.hours.absoluteValue.inMilliseconds).toLong()),
+        Date((now.time - 24.hours.absoluteValue.inWholeMilliseconds).toLong()),
+        Date((now.time - 24.hours.absoluteValue.inWholeMilliseconds).toLong()),
+        Date((now.time - 48.hours.absoluteValue.inWholeMilliseconds).toLong()),
+        Date((now.time - 48.hours.absoluteValue.inWholeMilliseconds).toLong()),
+        Date((now.time - 72.hours.absoluteValue.inWholeMilliseconds).toLong()),
+        Date((now.time - 96.hours.absoluteValue.inWholeMilliseconds).toLong()),
+        Date((now.time - 96.hours.absoluteValue.inWholeMilliseconds).toLong()),
+        Date((now.time - 96.hours.absoluteValue.inWholeMilliseconds).toLong()),
+        Date((now.time - 96.hours.absoluteValue.inWholeMilliseconds).toLong()),
     )
 
     private val datesNoStreak2 = listOf(
-        Date((now.time - 48.hours.absoluteValue.inMilliseconds).toLong()),
-        Date((now.time - 72.hours.absoluteValue.inMilliseconds).toLong()),
-        Date((now.time - 96.hours.absoluteValue.inMilliseconds).toLong()),
-        Date((now.time - 110.hours.absoluteValue.inMilliseconds).toLong()),
-        Date((now.time - 134.hours.absoluteValue.inMilliseconds).toLong()),
+        Date((now.time - 48.hours.absoluteValue.inWholeMilliseconds).toLong()),
+        Date((now.time - 72.hours.absoluteValue.inWholeMilliseconds).toLong()),
+        Date((now.time - 96.hours.absoluteValue.inWholeMilliseconds).toLong()),
+        Date((now.time - 110.hours.absoluteValue.inWholeMilliseconds).toLong()),
+        Date((now.time - 134.hours.absoluteValue.inWholeMilliseconds).toLong()),
     )
 
     @Test
     fun `5 Day streak`() {
-        val streak = dates5Streak.currentDailyStreak
+        val streak = dates5Streak.currentDailyStreakInternal(now)
         assertEquals(5, streak)
     }
 
     @Test
     fun `3 Day streak`() {
-        val streak = dates5Streak.subList(0, 3).currentDailyStreak
+        val streak = dates5Streak.subList(0, 3).currentDailyStreakInternal(now)
         assertEquals(3, streak)
     }
 
     @Test
     fun `3 Day streak with fourth day seperated by gap`() {
-        val streak = dates3StreakInterrupted.currentDailyStreak
+        val streak = dates3StreakInterrupted.currentDailyStreakInternal(now)
         assertEquals(3, streak)
     }
 
     @Test
     fun `1 Day streak`() {
-        val streak = dates5Streak.subList(0, 1).currentDailyStreak
+        val streak = dates5Streak.subList(0, 1).currentDailyStreakInternal(now)
         assertEquals(1, streak)
     }
 
     @Test
     fun `No workout today, no streak`() {
-        val streak = datesNoStreak.currentDailyStreak
+        val streak = datesNoStreak.currentDailyStreakInternal(now)
         assertEquals(0, streak)
     }
 
     @Test
     fun `No streak 2`() {
-        val streak = datesNoStreak2.currentDailyStreak
+        val streak = datesNoStreak2.currentDailyStreakInternal(now)
         assertEquals(0, streak)
     }
 
     @Test
     fun `1 Day streak 2`() {
+        val reference = Date(1616841912690)
         val streak = listOf(
             Date(1616713200000),
             Date(0),
-            Date(1616841912690)
-        ).currentDailyStreak
+            reference
+        ).currentDailyStreakInternal(reference)
         assertEquals(1, streak)
     }
 
     @Test
     fun `Empty workout list, no streak`() {
-        val streak = emptyList<Date>().currentDailyStreak
+        val streak = emptyList<Date>().currentDailyStreakInternal(now)
         assertEquals(0, streak)
     }
 
     @Test
     fun `5 Day streak with multiple dates per day`() {
-        val streak = dates5StreakMultipleADay.currentDailyStreak
+        val streak = dates5StreakMultipleADay.currentDailyStreakInternal(now)
         assertEquals(5, streak)
     }
 }

--- a/app/src/test/java/com/noahjutz/gymroutines/ui/workout/insights/WorkoutInsightsViewModelTest.kt
+++ b/app/src/test/java/com/noahjutz/gymroutines/ui/workout/insights/WorkoutInsightsViewModelTest.kt
@@ -1,0 +1,199 @@
+package com.noahjutz.gymroutines.ui.workout.insights
+
+import com.noahjutz.gymroutines.data.domain.Workout
+import com.noahjutz.gymroutines.data.domain.WorkoutSet
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
+import java.util.Date
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class WorkoutInsightsViewModelTest {
+
+    @Test
+    fun increasingLoadProducesLoadAndOneRmPrs() {
+        val exerciseId = 101
+        val baseInstant = Instant.parse("2023-01-01T10:00:00Z")
+        val sessions = listOf(
+            createSession(
+                workoutId = 1,
+                instant = baseInstant,
+                exerciseId = exerciseId,
+                exerciseName = "Shoulder Press",
+                weight = 15.0,
+                reps = 8,
+            ),
+            createSession(
+                workoutId = 2,
+                instant = baseInstant.plus(1, ChronoUnit.DAYS),
+                exerciseId = exerciseId,
+                exerciseName = "Shoulder Press",
+                weight = 20.0,
+                reps = 8,
+            ),
+        )
+
+        val result = computePersonalRecords(sessions)
+
+        val loadEvents = result.events.filter { it.type == PrType.Load }
+        assertEquals(2, loadEvents.size)
+        assertEquals(20.0, loadEvents.first().value, 1e-6)
+
+        val oneRmEvents = result.events.filter { it.type == PrType.EstimatedOneRm }
+        assertEquals(2, oneRmEvents.size)
+        assertTrue(oneRmEvents.first().value > oneRmEvents.last().value)
+
+        val secondWorkoutEvents = result.eventsByWorkout[2]
+        assertNotNull(secondWorkoutEvents)
+        assertTrue(secondWorkoutEvents.any { it.type == PrType.Load && it.value == 20.0 })
+    }
+
+    @Test
+    fun zeroAndNegativeWeightsAreIgnored() {
+        val baseInstant = Instant.parse("2023-02-01T08:00:00Z")
+        val sessions = listOf(
+            createSession(
+                workoutId = 10,
+                instant = baseInstant,
+                exerciseId = 33,
+                exerciseName = "Bench Press",
+                weight = 0.0,
+                reps = 10,
+            ),
+            createSession(
+                workoutId = 11,
+                instant = baseInstant.plus(1, ChronoUnit.DAYS),
+                exerciseId = 33,
+                exerciseName = "Bench Press",
+                weight = -5.0,
+                reps = 8,
+            ),
+        )
+
+        val result = computePersonalRecords(sessions)
+
+        assertTrue(result.events.isEmpty())
+        assertTrue(result.eventsByWorkout[10].isNullOrEmpty())
+        assertTrue(result.eventsByWorkout[11].isNullOrEmpty())
+    }
+
+    @Test
+    fun repeatedWeightsWithNoiseDoNotCreateDuplicateRecords() {
+        val baseInstant = Instant.parse("2023-03-10T07:30:00Z")
+        val exerciseId = 12
+        val sessions = listOf(
+            createSession(
+                workoutId = 21,
+                instant = baseInstant,
+                exerciseId = exerciseId,
+                exerciseName = "Deadlift",
+                weight = 20.0,
+                reps = 5,
+            ),
+            createSession(
+                workoutId = 22,
+                instant = baseInstant.plus(1, ChronoUnit.DAYS),
+                exerciseId = exerciseId,
+                exerciseName = "Deadlift",
+                weight = 20.0004,
+                reps = 5,
+            ),
+            createSession(
+                workoutId = 23,
+                instant = baseInstant.plus(2, ChronoUnit.DAYS),
+                exerciseId = exerciseId,
+                exerciseName = "Deadlift",
+                weight = 20.1,
+                reps = 5,
+            ),
+        )
+
+        val result = computePersonalRecords(sessions)
+
+        val loadEvents = result.events.filter { it.type == PrType.Load }
+        assertEquals(2, loadEvents.size)
+        assertTrue(result.eventsByWorkout[22].isNullOrEmpty())
+        assertTrue(result.eventsByWorkout[23]?.any { it.type == PrType.Load } == true)
+    }
+
+    @Test
+    fun normalizeWeightDropsInvalidValuesAndRounds() {
+        assertNull(normalizeWeight(null))
+        assertNull(normalizeWeight(Double.NaN))
+        assertNull(normalizeWeight(-1.0))
+        assertEquals(20.12, normalizeWeight(20.123) ?: error("weight should normalize"), 1e-6)
+    }
+
+    private fun createSession(
+        workoutId: Int,
+        instant: Instant,
+        exerciseId: Int,
+        exerciseName: String,
+        weight: Double?,
+        reps: Int?,
+    ): SessionComputation {
+        val normalizedWeight = normalizeWeight(weight)
+        val workout = Workout(
+            routineId = 1,
+            startTime = Date.from(instant),
+            endTime = Date.from(instant.plus(1, ChronoUnit.HOURS)),
+            workoutId = workoutId,
+        )
+        val totalReps = reps ?: 0
+        val totalVolume = if (normalizedWeight != null && totalReps > 0) normalizedWeight * totalReps else 0.0
+        val averageLoad = if (normalizedWeight != null && totalReps > 0) normalizedWeight else 0.0
+        val bestLoad = normalizedWeight
+        val bestEst = if (normalizedWeight != null && totalReps > 0) {
+            roundToDecimals(epley(normalizedWeight, totalReps), 2)
+        } else {
+            normalizedWeight
+        }
+        val summary = ExerciseSessionSummary(
+            exerciseId = exerciseId,
+            exerciseName = exerciseName,
+            totalVolume = totalVolume,
+            totalReps = totalReps,
+            averageLoad = averageLoad,
+            bestLoad = bestLoad,
+            bestEst = bestEst,
+        )
+        val dailyBest = DailyBest(
+            bestLoad = bestLoad ?: 0.0,
+            bestEst = bestEst ?: (bestLoad ?: 0.0),
+            label = exerciseName,
+        )
+        val set = WorkoutSet(
+            groupId = 1,
+            reps = reps,
+            weight = weight,
+        )
+        val sample = WorkoutSetSample(
+            exerciseId = exerciseId,
+            exerciseName = exerciseName,
+            normalizedExerciseName = exerciseName.lowercase(),
+            reps = reps,
+            weight = normalizedWeight,
+            rawSet = set,
+            startInstant = instant,
+        )
+
+        return SessionComputation(
+            workout = workout,
+            routineName = "Routine",
+            date = instant.atZone(ZoneId.systemDefault()).toLocalDate(),
+            durationMinutes = 60.0,
+            totalVolume = totalVolume,
+            totalReps = totalReps,
+            avgLoadPerRep = if (totalReps == 0) 0.0 else totalVolume / totalReps,
+            exerciseSummaries = mapOf(exerciseId to summary),
+            sets = listOf(sample),
+            startInstant = instant,
+            exerciseDailyBest = mapOf(exerciseId to dailyBest),
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- refactor the workout insights PR pipeline to use a reusable `computePersonalRecords` helper with normalized kilogram weights and shared data classes
- cover the new PR logic with unit tests that verify heavier loads, invalid weights, and noisy duplicates are handled as expected
- add a deterministic `currentDailyStreak` helper for DateUtil along with updated tests to exercise its behavior

## Testing
- ./gradlew test --console=plain
- ./gradlew assembleDebug --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e53370df50832480f9779867c4c7bb