### PR TITLE
Revamp UI styling for routines and workout flows

### DIFF
--- a/app/src/main/java/com/noahjutz/gymroutines/ui/components/SearchBar.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/components/SearchBar.kt
@@ -4,10 +4,14 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.material.*
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Search
@@ -31,30 +35,36 @@ fun SearchBar(
         value = value,
         onValueChange = onValueChange,
         singleLine = true,
-        textStyle = MaterialTheme.typography.h6.copy(color = MaterialTheme.colors.onSurface),
+        textStyle = MaterialTheme.typography.subtitle1.copy(color = MaterialTheme.colors.onSurface),
         cursorBrush = SolidColor(MaterialTheme.colors.onSurface),
         decorationBox = { innerTextField ->
             Surface(
-                modifier = Modifier.height(60.dp),
-                color = MaterialTheme.colors.onSurface.copy(alpha = 0.1f),
-                shape = RoundedCornerShape(30.dp)
+                modifier = Modifier.height(48.dp),
+                color = MaterialTheme.colors.surface,
+                shape = MaterialTheme.shapes.large,
+                elevation = 2.dp,
+                border = BorderStroke(1.dp, MaterialTheme.colors.onSurface.copy(alpha = 0.06f))
             ) {
                 Row(
-                    Modifier.padding(start = 24.dp, end = 8.dp),
+                    Modifier.padding(horizontal = 16.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Icon(Icons.Default.Search, null)
-                    Spacer(Modifier.width(12.dp))
+                    Icon(
+                        Icons.Default.Search,
+                        contentDescription = null,
+                        tint = MaterialTheme.colors.onSurface.copy(alpha = 0.65f)
+                    )
+                    Spacer(Modifier.width(10.dp))
                     Box(
                         Modifier
-                            .padding(vertical = 16.dp)
+                            .padding(vertical = 2.dp)
                             .weight(1f)
                     ) {
                         if (value.isEmpty()) {
                             Text(
                                 stringResource(R.string.hint_search),
-                                style = MaterialTheme.typography.h6.copy(
-                                    color = MaterialTheme.colors.onSurface.copy(alpha = 0.12f)
+                                style = MaterialTheme.typography.subtitle1.copy(
+                                    color = MaterialTheme.colors.onSurface.copy(alpha = 0.38f)
                                 )
                             )
                         }
@@ -65,9 +75,13 @@ fun SearchBar(
                         enter = fadeIn(),
                         exit = fadeOut()
                     ) {
-                        Spacer(Modifier.width(8.dp))
+                        Spacer(Modifier.width(6.dp))
                         IconButton(onClick = { onValueChange("") }) {
-                            Icon(Icons.Default.Clear, stringResource(R.string.btn_clear_text))
+                            Icon(
+                                Icons.Default.Clear,
+                                stringResource(R.string.btn_clear_text),
+                                tint = MaterialTheme.colors.onSurface.copy(alpha = 0.65f)
+                            )
                         }
                     }
                 }

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/components/SwipeToDismissBackground.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/components/SwipeToDismissBackground.kt
@@ -26,12 +26,14 @@ import androidx.compose.material.DismissDirection
 import androidx.compose.material.DismissState
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.MaterialTheme.colors
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 
 @ExperimentalMaterialApi
@@ -43,9 +45,11 @@ fun SwipeToDeleteBackground(dismissState: DismissState) {
         else -> return
     }
     Box(
-        modifier = Modifier.fillMaxSize()
-            .background(colors.secondary)
-            .padding(horizontal = 20.dp),
+        modifier = Modifier
+            .fillMaxSize()
+            .clip(MaterialTheme.shapes.medium)
+            .background(colors.secondary.copy(alpha = 0.9f))
+            .padding(horizontal = 16.dp),
         contentAlignment = alignment
     ) {
         Icon(Icons.Default.Delete, null, tint = colors.onSecondary)

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/exercises/list/ExerciseList.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/exercises/list/ExerciseList.kt
@@ -33,6 +33,7 @@ import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
@@ -77,9 +78,17 @@ fun ExerciseList(
         },
         floatingActionButton = {
             ExtendedFloatingActionButton(
+                modifier = Modifier.defaultMinSize(minHeight = 48.dp),
                 onClick = { navToExerciseEditor(-1) },
                 icon = { Icon(Icons.Default.Add, null) },
                 text = { Text(stringResource(R.string.btn_new_exercise)) },
+                shape = MaterialTheme.shapes.large,
+                backgroundColor = MaterialTheme.colors.secondary,
+                contentColor = MaterialTheme.colors.onSecondary,
+                elevation = FloatingActionButtonDefaults.elevation(
+                    defaultElevation = 4.dp,
+                    pressedElevation = 8.dp
+                )
             )
         },
     ) { paddingValues ->
@@ -109,12 +118,15 @@ private fun ExerciseListContent(
     viewModel: ExerciseListViewModel
 ) {
     val scope = rememberCoroutineScope()
-    LazyColumn(Modifier.fillMaxHeight()) {
+    LazyColumn(
+        modifier = Modifier.fillMaxHeight(),
+        contentPadding = PaddingValues(vertical = 8.dp)
+    ) {
         item {
             val searchQuery by viewModel.nameFilter.collectAsState()
             SearchBar(
                 modifier = Modifier
-                    .padding(16.dp)
+                    .padding(horizontal = 16.dp, vertical = 12.dp)
                     .fillMaxWidth(),
                 value = searchQuery,
                 onValueChange = viewModel::setNameFilter
@@ -132,17 +144,30 @@ private fun ExerciseListContent(
                 background = { SwipeToDeleteBackground(dismissState) }
             ) {
                 Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 6.dp),
+                    shape = MaterialTheme.shapes.medium,
                     elevation = animateDpAsState(
-                        if (dismissState.dismissDirection != null) 4.dp else 0.dp
+                        if (dismissState.dismissDirection != null) 6.dp else 2.dp
                     ).value
                 ) {
                     ListItem(
-                        Modifier.clickable { navToExerciseEditor(exercise.exerciseId) },
+                        modifier = Modifier
+                            .clickable { navToExerciseEditor(exercise.exerciseId) }
+                            .padding(horizontal = 12.dp, vertical = 4.dp),
+                        icon = null,
+                        secondaryText = null,
+                        overlineText = null,
+                        singleLineSecondaryText = true,
                         text = {
                             Text(
                                 text = exercise.name,
                                 maxLines = 1,
                                 overflow = TextOverflow.Ellipsis,
+                                style = MaterialTheme.typography.subtitle1.copy(
+                                    fontWeight = FontWeight.SemiBold
+                                )
                             )
                         },
                         trailing = {
@@ -182,7 +207,7 @@ private fun ExerciseListContent(
         }
         item {
             // Fix FAB overlap
-            Spacer(Modifier.height(72.dp))
+            Spacer(Modifier.height(56.dp))
         }
     }
 }

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/routines/list/RoutineList.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/routines/list/RoutineList.kt
@@ -33,6 +33,7 @@ import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
@@ -77,6 +78,7 @@ fun RoutineList(
         },
         floatingActionButton = {
             ExtendedFloatingActionButton(
+                modifier = Modifier.defaultMinSize(minHeight = 48.dp),
                 onClick = {
                     viewModel.addRoutine(
                         onComplete = { id ->
@@ -86,6 +88,13 @@ fun RoutineList(
                 },
                 icon = { Icon(Icons.Default.Add, null) },
                 text = { Text(stringResource(R.string.btn_new_routine)) },
+                shape = MaterialTheme.shapes.large,
+                backgroundColor = MaterialTheme.colors.secondary,
+                contentColor = MaterialTheme.colors.onSecondary,
+                elevation = FloatingActionButtonDefaults.elevation(
+                    defaultElevation = 4.dp,
+                    pressedElevation = 8.dp
+                )
             )
         },
     ) { paddingValues ->
@@ -115,13 +124,16 @@ fun RoutineListContent(
     viewModel: RoutineListViewModel
 ) {
     val scope = rememberCoroutineScope()
-    LazyColumn(Modifier.fillMaxHeight()) {
+    LazyColumn(
+        modifier = Modifier.fillMaxHeight(),
+        contentPadding = PaddingValues(vertical = 8.dp)
+    ) {
         item {
             val nameFilter by viewModel.nameFilter.collectAsState()
             SearchBar(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(16.dp),
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
                 value = nameFilter,
                 onValueChange = viewModel::setNameFilter
             )
@@ -138,18 +150,31 @@ fun RoutineListContent(
                 background = { SwipeToDeleteBackground(dismissState) }
             ) {
                 Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 6.dp),
+                    shape = MaterialTheme.shapes.medium,
                     elevation = animateDpAsState(
-                        if (dismissState.dismissDirection != null) 4.dp else 0.dp
+                        if (dismissState.dismissDirection != null) 6.dp else 2.dp
                     ).value
                 ) {
                     ListItem(
-                        Modifier.clickable { navToRoutineEditor(routine.routineId.toLong()) },
+                        modifier = Modifier
+                            .clickable { navToRoutineEditor(routine.routineId.toLong()) }
+                            .padding(horizontal = 12.dp, vertical = 4.dp),
+                        icon = null,
+                        secondaryText = null,
+                        overlineText = null,
+                        singleLineSecondaryText = true,
                         text = {
                             Text(
                                 text = routine.name.takeIf { it.isNotBlank() }
                                     ?: stringResource(R.string.unnamed_routine),
                                 maxLines = 1,
                                 overflow = TextOverflow.Ellipsis,
+                                style = MaterialTheme.typography.subtitle1.copy(
+                                    fontWeight = FontWeight.SemiBold
+                                )
                             )
                         },
                         trailing = {
@@ -208,7 +233,7 @@ fun RoutineListContent(
         }
         item {
             // Fix FAB overlap
-            Box(Modifier.height(72.dp)) {}
+            Spacer(Modifier.height(56.dp))
         }
     }
 }

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/theme/Color.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/theme/Color.kt
@@ -2,8 +2,16 @@ package com.noahjutz.gymroutines.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
-val Primary = Color(0xFF673ab7)
-val PrimaryDark = Color(0xFF320b86)
-val PrimaryDesaturated = Color(0xFF9a67ea)
-val Secondary = Color(0xFFFF5252)
-val SecondaryDark = Color(0xFFC50E29)
+val Primary = Color(0xFF4A58C9)
+val PrimaryDark = Color(0xFF303A8F)
+val PrimaryDesaturated = Color(0xFF808CD7)
+val Secondary = Color(0xFFFF7A59)
+val SecondaryDark = Color(0xFFE0603C)
+
+val LightBackground = Color(0xFFF5F4FA)
+val LightSurface = Color(0xFFFFFFFF)
+val LightOnSurface = Color(0xFF1C1D26)
+
+val DarkBackground = Color(0xFF121214)
+val DarkSurface = Color(0xFF1E1F25)
+val DarkOnSurface = Color(0xFFE6E7F1)

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/theme/Theme.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/theme/Theme.kt
@@ -1,27 +1,44 @@
 package com.noahjutz.gymroutines.ui.theme
 
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Shapes
 import androidx.compose.material.darkColors
 import androidx.compose.material.lightColors
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
 
 val WhiteColorPalette = lightColors(
     primary = Primary,
     primaryVariant = PrimaryDark,
     secondary = Secondary,
     secondaryVariant = SecondaryDark,
+    background = LightBackground,
+    surface = LightSurface,
     onPrimary = Color.White,
-    onSecondary = Color.Black,
+    onSecondary = Color.White,
+    onBackground = LightOnSurface,
+    onSurface = LightOnSurface,
 )
 
 val BlackColorPalette = darkColors(
     primary = PrimaryDesaturated,
     primaryVariant = PrimaryDark,
     secondary = Secondary,
-    secondaryVariant = Secondary,
-    onPrimary = Color.Black,
-    onSecondary = Color.Black,
+    secondaryVariant = SecondaryDark,
+    background = DarkBackground,
+    surface = DarkSurface,
+    onPrimary = Color.White,
+    onSecondary = Color.White,
+    onBackground = DarkOnSurface,
+    onSurface = DarkOnSurface,
+)
+
+private val GymShapes = Shapes(
+    small = RoundedCornerShape(8.dp),
+    medium = RoundedCornerShape(12.dp),
+    large = RoundedCornerShape(20.dp)
 )
 
 @Composable
@@ -31,6 +48,7 @@ fun GymRoutinesTheme(
 ) {
     MaterialTheme(
         colors = if (isDark) BlackColorPalette else WhiteColorPalette,
+        shapes = GymShapes,
         content = content
     )
 }

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/workout/in_progress/WorkoutInProgress.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/workout/in_progress/WorkoutInProgress.kt
@@ -23,6 +23,7 @@ import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -34,16 +35,17 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.selection.toggleable
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.AlertDialog
 import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Card
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.DismissValue
@@ -52,6 +54,7 @@ import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.MaterialTheme.colors
 import androidx.compose.material.MaterialTheme.typography
 import androidx.compose.material.OutlinedButton
@@ -170,31 +173,35 @@ private fun WorkoutInProgressContent(
     )
 
     LazyColumn(
-        Modifier
+        modifier = Modifier
             .fillMaxHeight()
-            .padding(horizontal = 24.dp)
+            .padding(horizontal = 16.dp, vertical = 8.dp)
     ) {
         item {
             Surface(
-                Modifier
+                modifier = Modifier
                     .fillMaxWidth()
-                    .padding(top = 24.dp),
-                color = colors.onSurface.copy(alpha = 0.1f),
-                shape = RoundedCornerShape(24.dp)
+                    .padding(top = 12.dp),
+                color = colors.primary.copy(alpha = 0.08f),
+                shape = MaterialTheme.shapes.large,
+                elevation = 0.dp
             ) {
                 val routineName by viewModel.routineName.collectAsState("")
                 Text(
                     text = routineName,
-                    modifier = Modifier.padding(24.dp),
-                    style = typography.h3,
+                    modifier = Modifier.padding(horizontal = 20.dp, vertical = 16.dp),
+                    style = typography.h5.copy(fontWeight = FontWeight.SemiBold),
                 )
             }
             Text(
                 workout.workout.duration.pretty(),
                 Modifier
                     .fillMaxWidth()
-                    .padding(top = 24.dp),
-                style = typography.h4.copy(textAlign = TextAlign.Center)
+                    .padding(top = 12.dp, bottom = 4.dp),
+                style = typography.subtitle1.copy(
+                    textAlign = TextAlign.Center,
+                    color = colors.onSurface.copy(alpha = 0.75f)
+                )
             )
         }
 
@@ -205,32 +212,38 @@ private fun WorkoutInProgressContent(
                 Modifier
                     .fillMaxWidth()
                     .animateItemPlacement()
-                    .padding(top = 24.dp),
-                shape = RoundedCornerShape(24.dp),
+                    .padding(top = 16.dp),
+                shape = MaterialTheme.shapes.large,
             ) {
                 Column {
-                    Surface(Modifier.fillMaxWidth(), color = colors.primary) {
+                    Surface(
+                        modifier = Modifier.fillMaxWidth(),
+                        color = colors.primary,
+                        shape = MaterialTheme.shapes.large
+                    ) {
                         Row(
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
                             horizontalArrangement = Arrangement.SpaceBetween,
                             verticalAlignment = Alignment.CenterVertically
                         ) {
                             Text(
                                 exercise?.name.toString(),
-                                style = typography.h5,
-                                modifier = Modifier
-                                    .padding(16.dp)
-                                    .weight(1f)
+                                style = typography.h6.copy(
+                                    fontWeight = FontWeight.SemiBold,
+                                    color = colors.onPrimary
+                                ),
+                                modifier = Modifier.weight(1f)
                             )
 
                             Box {
                                 var expanded by remember { mutableStateOf(false) }
                                 IconButton(
-                                    modifier = Modifier.padding(16.dp),
                                     onClick = { expanded = !expanded }
                                 ) {
                                     Icon(
                                         Icons.Default.DragHandle,
-                                        stringResource(R.string.drag_handle)
+                                        stringResource(R.string.drag_handle),
+                                        tint = colors.onPrimary
                                     )
                                 }
                                 DropdownMenu(
@@ -271,21 +284,20 @@ private fun WorkoutInProgressContent(
                             }
                         }
                     }
-                    Column(Modifier.padding(vertical = 16.dp)) {
+                    Column(Modifier.padding(horizontal = 12.dp, vertical = 12.dp)) {
                         Row(Modifier.padding(horizontal = 4.dp)) {
-                            val headerTextStyle = TextStyle(
+                            val headerTextStyle = typography.subtitle2.copy(
                                 color = colors.onSurface,
-                                fontSize = 16.sp,
-                                fontWeight = FontWeight.Bold,
+                                fontWeight = FontWeight.SemiBold,
                                 textAlign = TextAlign.Center
                             )
                             if (exercise?.logReps == true) Box(
                                 Modifier
                                     .padding(4.dp)
                                     .weight(1f)
-                                    .height(56.dp)
-                                    .clip(RoundedCornerShape(8.dp))
-                                    .background(colors.primary.copy(alpha = 0.1f)),
+                                    .height(48.dp)
+                                    .clip(MaterialTheme.shapes.small)
+                                    .background(colors.primary.copy(alpha = 0.08f)),
                                 contentAlignment = Alignment.Center
                             ) {
                                 Text(
@@ -297,9 +309,9 @@ private fun WorkoutInProgressContent(
                                 Modifier
                                     .padding(4.dp)
                                     .weight(1f)
-                                    .height(56.dp)
-                                    .clip(RoundedCornerShape(8.dp))
-                                    .background(colors.primary.copy(alpha = 0.1f)),
+                                    .height(48.dp)
+                                    .clip(MaterialTheme.shapes.small)
+                                    .background(colors.primary.copy(alpha = 0.08f)),
                                 contentAlignment = Alignment.Center
                             ) {
                                 Text(
@@ -311,9 +323,9 @@ private fun WorkoutInProgressContent(
                                 Modifier
                                     .padding(4.dp)
                                     .weight(1f)
-                                    .height(56.dp)
-                                    .clip(RoundedCornerShape(8.dp))
-                                    .background(colors.primary.copy(alpha = 0.1f)),
+                                    .height(48.dp)
+                                    .clip(MaterialTheme.shapes.small)
+                                    .background(colors.primary.copy(alpha = 0.08f)),
                                 contentAlignment = Alignment.Center
                             ) {
                                 Text(
@@ -325,9 +337,9 @@ private fun WorkoutInProgressContent(
                                 Modifier
                                     .padding(4.dp)
                                     .weight(1f)
-                                    .height(56.dp)
-                                    .clip(RoundedCornerShape(8.dp))
-                                    .background(colors.primary.copy(alpha = 0.1f)),
+                                    .height(48.dp)
+                                    .clip(MaterialTheme.shapes.small)
+                                    .background(colors.primary.copy(alpha = 0.08f)),
                                 contentAlignment = Alignment.Center
                             ) {
                                 Text(
@@ -338,14 +350,15 @@ private fun WorkoutInProgressContent(
                             Box(
                                 Modifier
                                     .padding(4.dp)
-                                    .size(56.dp)
-                                    .clip(RoundedCornerShape(8.dp))
-                                    .background(colors.primary.copy(alpha = 0.1f)),
+                                    .size(48.dp)
+                                    .clip(MaterialTheme.shapes.small)
+                                    .background(colors.primary.copy(alpha = 0.08f)),
                                 contentAlignment = Alignment.Center
                             ) {
                                 Icon(
                                     Icons.Default.Check,
-                                    stringResource(R.string.column_set_complete)
+                                    stringResource(R.string.column_set_complete),
+                                    tint = colors.primary
                                 )
                             }
                         }
@@ -362,9 +375,9 @@ private fun WorkoutInProgressContent(
                                     state = dismissState,
                                     background = { SwipeToDeleteBackground(dismissState) },
                                 ) {
-                                    Surface {
+                                    Surface(color = colors.surface) {
                                         Row(
-                                            Modifier.padding(horizontal = 4.dp)
+                                            Modifier.padding(horizontal = 4.dp, vertical = 2.dp)
                                         ) {
                                             val textFieldStyle = typography.body1.copy(
                                                 textAlign = TextAlign.Center,
@@ -373,13 +386,17 @@ private fun WorkoutInProgressContent(
                                             val decorationBox: @Composable (@Composable () -> Unit) -> Unit =
                                                 { innerTextField ->
                                                     Surface(
-                                                        color = colors.onSurface.copy(alpha = 0.1f),
-                                                        shape = RoundedCornerShape(8.dp),
+                                                        color = colors.surface,
+                                                        shape = MaterialTheme.shapes.small,
+                                                        border = BorderStroke(
+                                                            1.dp,
+                                                            colors.onSurface.copy(alpha = 0.08f)
+                                                        )
                                                     ) {
                                                         Box(
                                                             Modifier
-                                                                .padding(horizontal = 4.dp)
-                                                                .height(56.dp),
+                                                                .heightIn(min = 48.dp)
+                                                                .padding(horizontal = 6.dp),
                                                             contentAlignment = Alignment.Center
                                                         ) {
                                                             innerTextField()
@@ -486,8 +503,8 @@ private fun WorkoutInProgressContent(
                                             Box(
                                                 Modifier
                                                     .padding(4.dp)
-                                                    .size(56.dp)
-                                                    .clip(RoundedCornerShape(8.dp))
+                                                    .size(48.dp)
+                                                    .clip(MaterialTheme.shapes.small)
                                                     .toggleable(
                                                         value = set.complete,
                                                         onValueChange = {
@@ -497,7 +514,7 @@ private fun WorkoutInProgressContent(
                                                     .background(
                                                         animateColorAsState(
                                                             if (set.complete) colors.secondary else colors.onSurface.copy(
-                                                                alpha = 0.1f
+                                                                alpha = 0.06f
                                                             )
                                                         ).value
                                                     ),
@@ -524,11 +541,13 @@ private fun WorkoutInProgressContent(
                     TextButton(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .height(64.dp),
+                            .padding(horizontal = 12.dp)
+                            .height(52.dp),
+                        shape = MaterialTheme.shapes.medium,
                         onClick = { viewModel.addSet(setGroup) },
                     ) {
                         Icon(Icons.Default.Add, null)
-                        Spacer(Modifier.width(12.dp))
+                        Spacer(Modifier.width(10.dp))
                         Text(stringResource(R.string.btn_add_set))
                     }
                 }
@@ -538,36 +557,38 @@ private fun WorkoutInProgressContent(
         item {
             Button(
                 modifier = Modifier
-                    .padding(top = 24.dp)
+                    .padding(top = 16.dp)
                     .fillMaxWidth()
-                    .height(128.dp),
-                shape = RoundedCornerShape(24.dp),
+                    .height(72.dp),
+                shape = MaterialTheme.shapes.large,
+                elevation = ButtonDefaults.elevation(defaultElevation = 0.dp, pressedElevation = 2.dp),
                 onClick = navToExercisePicker
             ) {
                 Icon(Icons.Default.Add, null)
-                Spacer(Modifier.width(12.dp))
+                Spacer(Modifier.width(10.dp))
                 Text(stringResource(R.string.btn_add_exercise))
             }
 
             Row(
                 Modifier
                     .fillMaxWidth()
-                    .padding(vertical = 24.dp),
+                    .padding(vertical = 16.dp),
                 horizontalArrangement = Arrangement.Center,
             ) {
                 OutlinedButton(
-                    modifier = Modifier.height(40.dp),
-                    shape = RoundedCornerShape(percent = 100),
+                    modifier = Modifier.height(44.dp),
+                    shape = MaterialTheme.shapes.medium,
                     onClick = { showCancelWorkoutDialog = true },
                 ) {
                     Text(stringResource(R.string.btn_discard_workout))
                 }
-                Spacer(Modifier.width(16.dp))
+                Spacer(Modifier.width(12.dp))
                 Button(
                     modifier = Modifier
                         .weight(1f)
-                        .height(40.dp),
-                    shape = RoundedCornerShape(percent = 100),
+                        .height(48.dp),
+                    shape = MaterialTheme.shapes.medium,
+                    elevation = ButtonDefaults.elevation(defaultElevation = 0.dp, pressedElevation = 2.dp),
                     onClick = { showFinishWorkoutDialog = true }
                 ) {
                     Text(stringResource(R.string.btn_finish_workout))


### PR DESCRIPTION
## Summary
- refresh the app color palette and material shapes to create calmer light and dark themes
- tighten layout, spacing, and button treatments across routine and exercise lists with a refined search bar
- streamline workout-in-progress cards and inputs for better density while polishing swipe backgrounds and controls

## Testing
- ./gradlew assembleDebug --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e54ff5fad88324bb98800c5472113f