### PR TITLE
Refine routine editor and workout screens

### DIFF
--- a/app/src/main/java/com/noahjutz/gymroutines/ui/routines/editor/RoutineEditor.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/routines/editor/RoutineEditor.kt
@@ -31,10 +31,12 @@ import androidx.compose.material.MaterialTheme.colors
 import androidx.compose.material.MaterialTheme.typography
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
+import androidx.compose.material.contentColorFor
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -79,6 +81,7 @@ fun RoutineEditor(
         floatingActionButton = {
             val isWorkoutRunning by viewModel.isWorkoutInProgress.collectAsState(initial = false)
             if (!isWorkoutRunning) {
+                val fabBackground = lerp(colors.surface, colors.primary, 0.45f)
                 ExtendedFloatingActionButton(
                     onClick = {
                         viewModel.startWorkout { id ->
@@ -87,6 +90,8 @@ fun RoutineEditor(
                     },
                     icon = { Icon(Icons.Default.PlayArrow, null) },
                     text = { Text(stringResource(R.string.btn_start_workout)) },
+                    backgroundColor = fabBackground,
+                    contentColor = contentColorFor(fabBackground)
                 )
             }
         },
@@ -155,8 +160,8 @@ private fun RoutineEditorContent(
     LazyColumn(
         modifier = Modifier
             .fillMaxHeight()
-            .padding(horizontal = 24.dp),
-        contentPadding = PaddingValues(top = 16.dp, bottom = 70.dp)
+            .padding(horizontal = 20.dp),
+        contentPadding = PaddingValues(top = 12.dp, bottom = 64.dp)
     ) {
 
         item {
@@ -174,17 +179,17 @@ private fun RoutineEditorContent(
                 cursorBrush = SolidColor(colors.onSurface),
                 decorationBox = { innerTextField ->
                     Surface(
-                        modifier = if (nameLineCount <= 1) Modifier.height(60.dp) else Modifier,
-                        color = colors.onSurface.copy(alpha = 0.1f),
-                        shape = RoundedCornerShape(30.dp)
+                        modifier = if (nameLineCount <= 1) Modifier.height(48.dp) else Modifier,
+                        color = colors.onSurface.copy(alpha = 0.08f),
+                        shape = RoundedCornerShape(24.dp)
                     ) {
                         Row(
-                            Modifier.padding(start = 30.dp, end = 8.dp),
+                            Modifier.padding(start = 20.dp, end = 8.dp),
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
                             Box(
                                 Modifier
-                                    .padding(vertical = 16.dp)
+                                    .padding(vertical = 10.dp)
                                     .weight(1f)
                             ) {
                                 if (routine.name.isEmpty()) {
@@ -202,7 +207,7 @@ private fun RoutineEditorContent(
                                 enter = fadeIn(),
                                 exit = fadeOut()
                             ) {
-                                Spacer(Modifier.width(8.dp))
+                                Spacer(Modifier.width(4.dp))
                                 IconButton(onClick = { setName("") }) {
                                     Icon(
                                         Icons.Default.Clear,
@@ -218,31 +223,32 @@ private fun RoutineEditorContent(
 
         items(setGroups.sortedBy { it.group.position }, key = { it.group.id }) { setGroup ->
             val exercise = viewModel.getExercise(setGroup.group.exerciseId)!!
+            val headerColor = lerp(colors.surface, colors.primary, 0.32f)
             Card(
                 Modifier
                     .fillMaxWidth()
                     .animateItemPlacement()
-                    .padding(top = 30.dp),
-                shape = RoundedCornerShape(30.dp),
+                    .padding(top = 20.dp),
+                shape = RoundedCornerShape(22.dp),
             ) {
                 Column {
-                    Surface(Modifier.fillMaxWidth(), color = colors.primary) {
+                    Surface(Modifier.fillMaxWidth(), color = headerColor) {
                         Row(
                             horizontalArrangement = Arrangement.SpaceBetween,
                             verticalAlignment = Alignment.CenterVertically
                         ) {
                             Text(
                                 exercise.name,
-                                style = typography.h5,
+                                style = typography.h6,
                                 modifier = Modifier
-                                    .padding(16.dp)
+                                    .padding(horizontal = 16.dp, vertical = 10.dp)
                                     .weight(1f)
                             )
 
                             Box {
                                 var expanded by remember { mutableStateOf(false) }
                                 IconButton(
-                                    modifier = Modifier.padding(16.dp),
+                                    modifier = Modifier.padding(end = 6.dp),
                                     onClick = { expanded = !expanded }
                                 ) {
                                     Icon(
@@ -288,17 +294,17 @@ private fun RoutineEditorContent(
                             }
                         }
                     }
-                    Column(Modifier.padding(vertical = 16.dp)) {
-                        Row(Modifier.padding(horizontal = 4.dp)) {
+                    Column(Modifier.padding(vertical = 12.dp, horizontal = 8.dp)) {
+                        Row(Modifier.padding(horizontal = 2.dp)) {
                             val headerTextStyle = TextStyle(
                                 color = colors.onSurface,
-                                fontSize = 16.sp,
-                                fontWeight = FontWeight.Bold,
+                                fontSize = 14.sp,
+                                fontWeight = FontWeight.Medium,
                                 textAlign = TextAlign.Center
                             )
                             if (exercise.logReps) Surface(
                                 Modifier
-                                    .padding(horizontal = 4.dp, vertical = 8.dp)
+                                    .padding(horizontal = 4.dp, vertical = 4.dp)
                                     .weight(1f),
                             ) {
                                 Text(
@@ -308,7 +314,7 @@ private fun RoutineEditorContent(
                             }
                             if (exercise.logWeight) Surface(
                                 Modifier
-                                    .padding(horizontal = 4.dp, vertical = 8.dp)
+                                    .padding(horizontal = 4.dp, vertical = 4.dp)
                                     .weight(1f),
                             ) {
                                 Text(
@@ -318,7 +324,7 @@ private fun RoutineEditorContent(
                             }
                             if (exercise.logTime) Surface(
                                 Modifier
-                                    .padding(horizontal = 4.dp, vertical = 8.dp)
+                                    .padding(horizontal = 4.dp, vertical = 4.dp)
                                     .weight(1f),
                             ) {
                                 Text(
@@ -328,7 +334,7 @@ private fun RoutineEditorContent(
                             }
                             if (exercise.logDistance) Surface(
                                 Modifier
-                                    .padding(horizontal = 4.dp, vertical = 8.dp)
+                                    .padding(horizontal = 4.dp, vertical = 4.dp)
                                     .weight(1f),
                             ) {
                                 Text(
@@ -347,7 +353,7 @@ private fun RoutineEditorContent(
                                 ) {
                                     Surface {
                                         Row(
-                                            Modifier.padding(horizontal = 4.dp)
+                                            Modifier.padding(horizontal = 2.dp)
                                         ) {
                                             val textFieldStyle = typography.body1.copy(
                                                 textAlign = TextAlign.Center,
@@ -356,13 +362,13 @@ private fun RoutineEditorContent(
                                             val decorationBox: @Composable (@Composable () -> Unit) -> Unit =
                                                 { innerTextField ->
                                                     Surface(
-                                                        color = colors.onSurface.copy(alpha = 0.1f),
-                                                        shape = RoundedCornerShape(8.dp),
+                                                        color = colors.onSurface.copy(alpha = 0.08f),
+                                                        shape = RoundedCornerShape(10.dp),
                                                     ) {
                                                         Box(
                                                             Modifier.padding(
-                                                                vertical = 16.dp,
-                                                                horizontal = 4.dp
+                                                                vertical = 10.dp,
+                                                                horizontal = 6.dp
                                                             ),
                                                             contentAlignment = Alignment.Center
                                                         ) {
@@ -379,7 +385,7 @@ private fun RoutineEditorContent(
                                                 AutoSelectTextField(
                                                     modifier = Modifier
                                                         .weight(1f)
-                                                        .padding(4.dp),
+                                                        .padding(3.dp),
                                                     value = reps,
                                                     onValueChange = {
                                                         if (it.matches(RegexPatterns.integer))
@@ -405,7 +411,7 @@ private fun RoutineEditorContent(
                                                 AutoSelectTextField(
                                                     modifier = Modifier
                                                         .weight(1f)
-                                                        .padding(4.dp),
+                                                        .padding(3.dp),
                                                     value = weight,
                                                     onValueChange = {
                                                         if (it.matches(RegexPatterns.float))
@@ -427,7 +433,7 @@ private fun RoutineEditorContent(
                                                 AutoSelectTextField(
                                                     modifier = Modifier
                                                         .weight(1f)
-                                                        .padding(4.dp),
+                                                        .padding(3.dp),
                                                     value = time,
                                                     onValueChange = {
                                                         if (it.matches(RegexPatterns.duration))
@@ -454,7 +460,7 @@ private fun RoutineEditorContent(
                                                 AutoSelectTextField(
                                                     modifier = Modifier
                                                         .weight(1f)
-                                                        .padding(4.dp),
+                                                        .padding(3.dp),
                                                     value = distance,
                                                     onValueChange = {
                                                         if (it.matches(RegexPatterns.float))
@@ -485,11 +491,11 @@ private fun RoutineEditorContent(
                     TextButton(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .height(64.dp),
+                            .height(48.dp),
                         onClick = { viewModel.addSet(setGroup) },
                     ) {
                         Icon(Icons.Default.Add, null)
-                        Spacer(Modifier.width(12.dp))
+                        Spacer(Modifier.width(8.dp))
                         Text(stringResource(R.string.btn_add_set))
                     }
                 }
@@ -500,13 +506,13 @@ private fun RoutineEditorContent(
             Button(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(30.dp)
-                    .height(120.dp),
-                shape = RoundedCornerShape(30.dp),
+                    .padding(24.dp)
+                    .height(72.dp),
+                shape = RoundedCornerShape(24.dp),
                 onClick = navToExercisePicker
             ) {
                 Icon(Icons.Default.Add, null)
-                Spacer(Modifier.width(12.dp))
+                Spacer(Modifier.width(8.dp))
                 Text(stringResource(R.string.btn_add_exercise))
             }
         }

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/workout/in_progress/WorkoutInProgress.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/workout/in_progress/WorkoutInProgress.kt
@@ -63,6 +63,7 @@ import androidx.compose.material.Surface
 import androidx.compose.material.SwipeToDismiss
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
+import androidx.compose.material.contentColorFor
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowBack
@@ -80,6 +81,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.graphics.lerp
 import com.noahjutz.gymroutines.R
 import com.noahjutz.gymroutines.data.domain.WorkoutWithSetGroups
 import com.noahjutz.gymroutines.data.domain.duration
@@ -175,30 +177,31 @@ private fun WorkoutInProgressContent(
     LazyColumn(
         modifier = Modifier
             .fillMaxHeight()
-            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .padding(horizontal = 16.dp, vertical = 6.dp)
     ) {
         item {
+            val routineNameBackground = lerp(colors.surface, colors.primary, 0.12f)
             Surface(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(top = 12.dp),
-                color = colors.primary.copy(alpha = 0.08f),
+                    .padding(top = 8.dp),
+                color = routineNameBackground,
                 shape = MaterialTheme.shapes.large,
                 elevation = 0.dp
             ) {
                 val routineName by viewModel.routineName.collectAsState("")
                 Text(
                     text = routineName,
-                    modifier = Modifier.padding(horizontal = 20.dp, vertical = 16.dp),
-                    style = typography.h5.copy(fontWeight = FontWeight.SemiBold),
+                    modifier = Modifier.padding(horizontal = 20.dp, vertical = 12.dp),
+                    style = typography.h6.copy(fontWeight = FontWeight.SemiBold),
                 )
             }
             Text(
                 workout.workout.duration.pretty(),
                 Modifier
                     .fillMaxWidth()
-                    .padding(top = 12.dp, bottom = 4.dp),
-                style = typography.subtitle1.copy(
+                    .padding(top = 8.dp, bottom = 4.dp),
+                style = typography.subtitle2.copy(
                     textAlign = TextAlign.Center,
                     color = colors.onSurface.copy(alpha = 0.75f)
                 )
@@ -208,21 +211,22 @@ private fun WorkoutInProgressContent(
         items(workout.setGroups.sortedBy { it.group.position }, key = { it.group.id }) { setGroup ->
             val exercise by viewModel.getExercise(setGroup.group.exerciseId)
                 .collectAsState(initial = null)
+            val headerColor = lerp(colors.surface, colors.primary, 0.32f)
             Card(
                 Modifier
                     .fillMaxWidth()
                     .animateItemPlacement()
-                    .padding(top = 16.dp),
-                shape = MaterialTheme.shapes.large,
+                    .padding(top = 14.dp),
+                shape = MaterialTheme.shapes.medium,
             ) {
                 Column {
                     Surface(
                         modifier = Modifier.fillMaxWidth(),
-                        color = colors.primary,
-                        shape = MaterialTheme.shapes.large
+                        color = headerColor,
+                        shape = MaterialTheme.shapes.medium
                     ) {
                         Row(
-                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp),
                             horizontalArrangement = Arrangement.SpaceBetween,
                             verticalAlignment = Alignment.CenterVertically
                         ) {
@@ -230,7 +234,7 @@ private fun WorkoutInProgressContent(
                                 exercise?.name.toString(),
                                 style = typography.h6.copy(
                                     fontWeight = FontWeight.SemiBold,
-                                    color = colors.onPrimary
+                                    color = contentColorFor(headerColor)
                                 ),
                                 modifier = Modifier.weight(1f)
                             )
@@ -243,7 +247,7 @@ private fun WorkoutInProgressContent(
                                     Icon(
                                         Icons.Default.DragHandle,
                                         stringResource(R.string.drag_handle),
-                                        tint = colors.onPrimary
+                                        tint = contentColorFor(headerColor)
                                     )
                                 }
                                 DropdownMenu(
@@ -284,20 +288,21 @@ private fun WorkoutInProgressContent(
                             }
                         }
                     }
-                    Column(Modifier.padding(horizontal = 12.dp, vertical = 12.dp)) {
-                        Row(Modifier.padding(horizontal = 4.dp)) {
-                            val headerTextStyle = typography.subtitle2.copy(
+                    Column(Modifier.padding(horizontal = 12.dp, vertical = 10.dp)) {
+                        Row(Modifier.padding(horizontal = 2.dp)) {
+                            val headerTextStyle = typography.caption.copy(
                                 color = colors.onSurface,
                                 fontWeight = FontWeight.SemiBold,
                                 textAlign = TextAlign.Center
                             )
+                            val headerBackground = colors.onSurface.copy(alpha = 0.06f)
                             if (exercise?.logReps == true) Box(
                                 Modifier
-                                    .padding(4.dp)
+                                    .padding(horizontal = 4.dp, vertical = 2.dp)
                                     .weight(1f)
-                                    .height(48.dp)
+                                    .height(40.dp)
                                     .clip(MaterialTheme.shapes.small)
-                                    .background(colors.primary.copy(alpha = 0.08f)),
+                                    .background(headerBackground),
                                 contentAlignment = Alignment.Center
                             ) {
                                 Text(
@@ -307,11 +312,11 @@ private fun WorkoutInProgressContent(
                             }
                             if (exercise?.logWeight == true) Box(
                                 Modifier
-                                    .padding(4.dp)
+                                    .padding(horizontal = 4.dp, vertical = 2.dp)
                                     .weight(1f)
-                                    .height(48.dp)
+                                    .height(40.dp)
                                     .clip(MaterialTheme.shapes.small)
-                                    .background(colors.primary.copy(alpha = 0.08f)),
+                                    .background(headerBackground),
                                 contentAlignment = Alignment.Center
                             ) {
                                 Text(
@@ -321,11 +326,11 @@ private fun WorkoutInProgressContent(
                             }
                             if (exercise?.logTime == true) Box(
                                 Modifier
-                                    .padding(4.dp)
+                                    .padding(horizontal = 4.dp, vertical = 2.dp)
                                     .weight(1f)
-                                    .height(48.dp)
+                                    .height(40.dp)
                                     .clip(MaterialTheme.shapes.small)
-                                    .background(colors.primary.copy(alpha = 0.08f)),
+                                    .background(headerBackground),
                                 contentAlignment = Alignment.Center
                             ) {
                                 Text(
@@ -335,11 +340,11 @@ private fun WorkoutInProgressContent(
                             }
                             if (exercise?.logDistance == true) Box(
                                 Modifier
-                                    .padding(4.dp)
+                                    .padding(horizontal = 4.dp, vertical = 2.dp)
                                     .weight(1f)
-                                    .height(48.dp)
+                                    .height(40.dp)
                                     .clip(MaterialTheme.shapes.small)
-                                    .background(colors.primary.copy(alpha = 0.08f)),
+                                    .background(headerBackground),
                                 contentAlignment = Alignment.Center
                             ) {
                                 Text(
@@ -349,10 +354,10 @@ private fun WorkoutInProgressContent(
                             }
                             Box(
                                 Modifier
-                                    .padding(4.dp)
-                                    .size(48.dp)
+                                    .padding(horizontal = 4.dp, vertical = 2.dp)
+                                    .size(40.dp)
                                     .clip(MaterialTheme.shapes.small)
-                                    .background(colors.primary.copy(alpha = 0.08f)),
+                                    .background(headerBackground),
                                 contentAlignment = Alignment.Center
                             ) {
                                 Icon(
@@ -377,7 +382,7 @@ private fun WorkoutInProgressContent(
                                 ) {
                                     Surface(color = colors.surface) {
                                         Row(
-                                            Modifier.padding(horizontal = 4.dp, vertical = 2.dp)
+                                            Modifier.padding(horizontal = 2.dp, vertical = 1.dp)
                                         ) {
                                             val textFieldStyle = typography.body1.copy(
                                                 textAlign = TextAlign.Center,
@@ -390,13 +395,13 @@ private fun WorkoutInProgressContent(
                                                         shape = MaterialTheme.shapes.small,
                                                         border = BorderStroke(
                                                             1.dp,
-                                                            colors.onSurface.copy(alpha = 0.08f)
+                                                            colors.onSurface.copy(alpha = 0.06f)
                                                         )
                                                     ) {
                                                         Box(
                                                             Modifier
-                                                                .heightIn(min = 48.dp)
-                                                                .padding(horizontal = 6.dp),
+                                                                .heightIn(min = 44.dp)
+                                                                .padding(horizontal = 6.dp, vertical = 6.dp),
                                                             contentAlignment = Alignment.Center
                                                         ) {
                                                             innerTextField()
@@ -412,7 +417,7 @@ private fun WorkoutInProgressContent(
                                                 AutoSelectTextField(
                                                     modifier = Modifier
                                                         .weight(1f)
-                                                        .padding(4.dp),
+                                                        .padding(3.dp),
                                                     value = reps,
                                                     onValueChange = {
                                                         if (it.matches(RegexPatterns.integer))
@@ -438,7 +443,7 @@ private fun WorkoutInProgressContent(
                                                 AutoSelectTextField(
                                                     modifier = Modifier
                                                         .weight(1f)
-                                                        .padding(4.dp),
+                                                        .padding(3.dp),
                                                     value = weight,
                                                     onValueChange = {
                                                         if (it.matches(RegexPatterns.float))
@@ -460,7 +465,7 @@ private fun WorkoutInProgressContent(
                                                 AutoSelectTextField(
                                                     modifier = Modifier
                                                         .weight(1f)
-                                                        .padding(4.dp),
+                                                        .padding(3.dp),
                                                     value = time,
                                                     onValueChange = {
                                                         if (it.matches(RegexPatterns.duration))
@@ -487,7 +492,7 @@ private fun WorkoutInProgressContent(
                                                 AutoSelectTextField(
                                                     modifier = Modifier
                                                         .weight(1f)
-                                                        .padding(4.dp),
+                                                        .padding(3.dp),
                                                     value = distance,
                                                     onValueChange = {
                                                         if (it.matches(RegexPatterns.float))
@@ -500,10 +505,20 @@ private fun WorkoutInProgressContent(
                                                     decorationBox = decorationBox
                                                 )
                                             }
+                                            val completionBackground by animateColorAsState(
+                                                if (set.complete) lerp(
+                                                    colors.surface,
+                                                    colors.secondary,
+                                                    0.45f
+                                                ) else colors.onSurface.copy(alpha = 0.05f)
+                                            )
+                                            val completionContent = if (set.complete) {
+                                                contentColorFor(completionBackground)
+                                            } else colors.onSurface
                                             Box(
                                                 Modifier
-                                                    .padding(4.dp)
-                                                    .size(48.dp)
+                                                    .padding(3.dp)
+                                                    .size(44.dp)
                                                     .clip(MaterialTheme.shapes.small)
                                                     .toggleable(
                                                         value = set.complete,
@@ -511,13 +526,7 @@ private fun WorkoutInProgressContent(
                                                             viewModel.updateChecked(set, it)
                                                         },
                                                     )
-                                                    .background(
-                                                        animateColorAsState(
-                                                            if (set.complete) colors.secondary else colors.onSurface.copy(
-                                                                alpha = 0.06f
-                                                            )
-                                                        ).value
-                                                    ),
+                                                    .background(completionBackground),
                                                 contentAlignment = Alignment.Center
                                             ) {
                                                 androidx.compose.animation.AnimatedVisibility(
@@ -528,7 +537,7 @@ private fun WorkoutInProgressContent(
                                                     Icon(
                                                         Icons.Default.Check,
                                                         stringResource(R.string.column_set_complete),
-                                                        tint = colors.onSecondary
+                                                        tint = completionContent
                                                     )
                                                 }
                                             }
@@ -542,12 +551,12 @@ private fun WorkoutInProgressContent(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(horizontal = 12.dp)
-                            .height(52.dp),
+                            .height(48.dp),
                         shape = MaterialTheme.shapes.medium,
                         onClick = { viewModel.addSet(setGroup) },
                     ) {
                         Icon(Icons.Default.Add, null)
-                        Spacer(Modifier.width(10.dp))
+                        Spacer(Modifier.width(8.dp))
                         Text(stringResource(R.string.btn_add_set))
                     }
                 }
@@ -557,15 +566,15 @@ private fun WorkoutInProgressContent(
         item {
             Button(
                 modifier = Modifier
-                    .padding(top = 16.dp)
+                    .padding(top = 12.dp)
                     .fillMaxWidth()
-                    .height(72.dp),
+                    .height(60.dp),
                 shape = MaterialTheme.shapes.large,
                 elevation = ButtonDefaults.elevation(defaultElevation = 0.dp, pressedElevation = 2.dp),
                 onClick = navToExercisePicker
             ) {
                 Icon(Icons.Default.Add, null)
-                Spacer(Modifier.width(10.dp))
+                Spacer(Modifier.width(8.dp))
                 Text(stringResource(R.string.btn_add_exercise))
             }
 


### PR DESCRIPTION
## Summary
- tighten spacing and typography on the routine editor so five sets fit without scrolling
- soften exercise header colors and adjust the start workout FAB to better match the palette
- mirror the compact layout and calmer color accents on the in-progress workout screen, including toned-down set completion controls

## Testing
- `./gradlew assembleDebug --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68e555883020832488c9d6786ba73044