### PR TITLE
Enable editing exercise notes across routine and workout screens

### DIFF
--- a/app/src/main/java/com/noahjutz/gymroutines/ui/components/EditExerciseNotesDialog.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/components/EditExerciseNotesDialog.kt
@@ -1,0 +1,62 @@
+package com.noahjutz.gymroutines.ui.components
+
+import androidx.compose.material.AlertDialog
+import androidx.compose.material.Button
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.input.TextFieldValue.Companion.Saver
+import androidx.compose.ui.text.style.TextAlign
+import com.noahjutz.gymroutines.R
+
+@Composable
+fun EditExerciseNotesDialog(
+    exerciseName: String,
+    initialNotes: String,
+    onDismiss: () -> Unit,
+    onConfirm: (String) -> Unit,
+) {
+    var notesValue by rememberSaveable(exerciseName, stateSaver = Saver) {
+        mutableStateOf(TextFieldValue(initialNotes))
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(
+                text = stringResource(R.string.dialog_title_edit_notes, exerciseName),
+                textAlign = TextAlign.Start,
+            )
+        },
+        text = {
+            OutlinedTextField(
+                value = notesValue,
+                onValueChange = { notesValue = it },
+                label = { Text(stringResource(R.string.label_exercise_notes)) },
+                singleLine = false,
+                maxLines = 6,
+            )
+        },
+        confirmButton = {
+            Button(
+                onClick = {
+                    onConfirm(notesValue.text)
+                }
+            ) {
+                Text(stringResource(R.string.btn_save))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.btn_cancel))
+            }
+        }
+    )
+}

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/routines/editor/RoutineEditorViewModel.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/routines/editor/RoutineEditorViewModel.kt
@@ -27,6 +27,7 @@ import com.noahjutz.gymroutines.data.AppPrefs
 import com.noahjutz.gymroutines.data.ExerciseRepository
 import com.noahjutz.gymroutines.data.RoutineRepository
 import com.noahjutz.gymroutines.data.WorkoutRepository
+import com.noahjutz.gymroutines.data.domain.Exercise
 import com.noahjutz.gymroutines.data.domain.Routine
 import com.noahjutz.gymroutines.data.domain.RoutineSet
 import com.noahjutz.gymroutines.data.domain.RoutineSetGroup
@@ -37,7 +38,6 @@ import com.noahjutz.gymroutines.data.domain.WorkoutSetGroup
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 
 class RoutineEditorViewModel(
     private val routineRepository: RoutineRepository,
@@ -70,7 +70,17 @@ class RoutineEditorViewModel(
         }
     }
 
-    fun getExercise(exerciseId: Int) = runBlocking { exerciseRepository.getExercise(exerciseId) }
+    fun getExercise(exerciseId: Int): Flow<Exercise?> {
+        return exerciseRepository.getExerciseFlow(exerciseId)
+    }
+
+    fun updateExerciseNotes(exerciseId: Int, notes: String) {
+        viewModelScope.launch {
+            exerciseRepository.getExercise(exerciseId)?.let { exercise ->
+                exerciseRepository.update(exercise.copy(notes = notes))
+            }
+        }
+    }
 
     fun updateName(name: String) {
         _routine?.let {

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/workout/in_progress/WorkoutInProgressViewModel.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/workout/in_progress/WorkoutInProgressViewModel.kt
@@ -155,6 +155,14 @@ class WorkoutInProgressViewModel(
         }
     }
 
+    fun updateExerciseNotes(exerciseId: Int, notes: String) {
+        viewModelScope.launch {
+            exerciseRepository.getExercise(exerciseId)?.let { exercise ->
+                exerciseRepository.update(exercise.copy(notes = notes))
+            }
+        }
+    }
+
     fun updateChecked(set: WorkoutSet, checked: Boolean) {
         viewModelScope.launch {
             workoutRepository.update(set.copy(complete = checked))

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,6 +55,10 @@
     <string name="btn_save">Save</string>
     <string name="label_exercise_name">Exercise name</string>
     <string name="label_exercise_notes">Notes</string>
+    <string name="btn_add_notes">Add notes</string>
+    <string name="btn_edit_notes">Edit notes</string>
+    <string name="dialog_title_edit_notes">Edit notes for %1$s</string>
+    <string name="unnamed_exercise">Unnamed exercise</string>
     <string name="btn_more">More</string>
     <string name="btn_delete">Delete</string>
     <string name="dialog_item_set">this set</string>


### PR DESCRIPTION
## Summary
- add a reusable dialog for editing exercise notes and hook it into the routine editor
- surface exercise notes (with add/edit actions) in the in-progress workout UI and refresh styling
- fetch exercise data via flows and reuse sorted set groups for lighter recompositions
- add repository helpers and strings needed for note editing

## Testing
- ./gradlew assembleDebug --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e57a97f0788324960f8a44beb790b4