### PR TITLE
Adjust warmup set handling

### DIFF
--- a/app/src/main/java/com/noahjutz/gymroutines/ui/routines/editor/RoutineEditor.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/routines/editor/RoutineEditor.kt
@@ -452,6 +452,7 @@ private fun RoutineEditorContent(
                                 )
                             }
                         }
+                        var workingSetIndex = 0
                         setGroup.sets.forEachIndexed { index, set ->
                             key(set.routineSetId) {
                                 val dismissState = rememberDismissState()
@@ -466,11 +467,16 @@ private fun RoutineEditorContent(
                                         ) {
                                             SetTypeBadge(
                                                 isWarmup = set.isWarmup,
-                                                index = index,
+                                                index = if (set.isWarmup) workingSetIndex else workingSetIndex++,
                                                 modifier = Modifier
                                                     .padding(3.dp)
                                                     .width(WarmupIndicatorWidth),
-                                                onToggle = { viewModel.updateWarmup(set, !set.isWarmup) }
+                                                onToggle = {
+                                                    val makeWarmup = !set.isWarmup
+                                                    if (!makeWarmup || setGroup.sets.take(index).all { it.isWarmup }) {
+                                                        viewModel.updateWarmup(set, makeWarmup)
+                                                    }
+                                                }
                                             )
                                             val textFieldStyle = typography.body1.copy(
                                                 textAlign = TextAlign.Center,

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/routines/editor/RoutineEditorViewModel.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/routines/editor/RoutineEditorViewModel.kt
@@ -170,8 +170,21 @@ class RoutineEditorViewModel(
 
     fun updateWarmup(set: RoutineSet, isWarmup: Boolean) {
         viewModelScope.launch {
+            if (isWarmup && !canBeWarmup(set)) return@launch
+
             routineRepository.update(set.copy(isWarmup = isWarmup))
         }
+    }
+
+    private fun canBeWarmup(set: RoutineSet): Boolean {
+        val setsInGroup = _sets
+            .filter { it.groupId == set.groupId }
+            .sortedBy { it.routineSetId }
+
+        val targetIndex = setsInGroup.indexOfFirst { it.routineSetId == set.routineSetId }
+        if (targetIndex < 0) return true
+
+        return setsInGroup.take(targetIndex).all { it.isWarmup }
     }
 
     fun startWorkout(onWorkoutStarted: (Long) -> Unit) {

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/workout/in_progress/WorkoutInProgress.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/workout/in_progress/WorkoutInProgress.kt
@@ -489,6 +489,7 @@ private fun WorkoutInProgressContent(
                                 )
                             }
                         }
+                        var workingSetIndex = 0
                         setGroup.sets.forEachIndexed { index, set ->
                             key(set.workoutSetId) {
                                 val dismissState = rememberDismissState()
@@ -508,11 +509,16 @@ private fun WorkoutInProgressContent(
                                         ) {
                                             SetTypeBadge(
                                                 isWarmup = set.isWarmup,
-                                                index = index,
+                                                index = if (set.isWarmup) workingSetIndex else workingSetIndex++,
                                                 modifier = Modifier
                                                     .padding(3.dp)
                                                     .width(WarmupIndicatorWidth),
-                                                onToggle = { pendingSetTypeChange = set to !set.isWarmup }
+                                                onToggle = {
+                                                    val makeWarmup = !set.isWarmup
+                                                    if (!makeWarmup || setGroup.sets.take(index).all { it.isWarmup }) {
+                                                        pendingSetTypeChange = set to makeWarmup
+                                                    }
+                                                }
                                             )
                                             val textFieldStyle = typography.body1.copy(
                                                 textAlign = TextAlign.Center,

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/workout/in_progress/WorkoutInProgressViewModel.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/workout/in_progress/WorkoutInProgressViewModel.kt
@@ -158,8 +158,23 @@ class WorkoutInProgressViewModel(
 
     fun updateWarmup(set: WorkoutSet, isWarmup: Boolean) {
         viewModelScope.launch {
+            if (isWarmup && !canBeWarmup(set)) return@launch
+
             workoutRepository.update(set.copy(isWarmup = isWarmup))
         }
+    }
+
+    private fun canBeWarmup(set: WorkoutSet): Boolean {
+        val setsInGroup = _workout?.setGroups
+            ?.firstOrNull { it.group.id == set.groupId }
+            ?.sets
+            ?.sortedBy { it.workoutSetId }
+            ?: return true
+
+        val targetIndex = setsInGroup.indexOfFirst { it.workoutSetId == set.workoutSetId }
+        if (targetIndex < 0) return true
+
+        return setsInGroup.take(targetIndex).all { it.isWarmup }
     }
 
     fun updateExerciseNotes(exerciseId: Int, notes: String) {

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/workout/viewer/WorkoutViewer.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/workout/viewer/WorkoutViewer.kt
@@ -209,7 +209,8 @@ fun WorkoutViewerContent(workout: WorkoutWithSetGroups, viewModel: WorkoutViewer
                                 Icon(Icons.Default.Check, null)
                             }
                         }
-                        setGroup.sets.forEachIndexed { index, set ->
+                        var workingSetIndex = 0
+                        setGroup.sets.forEach { set ->
                             Row(
                                 Modifier.padding(horizontal = 4.dp)
                             ) {
@@ -244,7 +245,7 @@ fun WorkoutViewerContent(workout: WorkoutWithSetGroups, viewModel: WorkoutViewer
                                     }
                                 SetTypeBadge(
                                     isWarmup = set.isWarmup,
-                                    index = index,
+                                    index = if (set.isWarmup) workingSetIndex else workingSetIndex++,
                                     modifier = Modifier
                                         .padding(4.dp)
                                         .width(WarmupIndicatorWidth)


### PR DESCRIPTION
## Summary
- ensure warm-up toggles only apply to leading sets in workout and routine editors
- recalculate working set numbering so warm-ups no longer shift displayed set numbers
- mirror numbering fixes in the workout viewer for consistent presentation

## Testing
- ./gradlew assembleDebug --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e65be7a1908324a6d4644879c82185