### PR TITLE
Improve rest timer UI and alerts

### DIFF
--- a/app/src/main/java/com/noahjutz/gymroutines/ui/workout/in_progress/WorkoutInProgress.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/workout/in_progress/WorkoutInProgress.kt
@@ -103,6 +103,7 @@ import com.noahjutz.gymroutines.util.pretty
 import com.noahjutz.gymroutines.util.toStringOrBlank
 import org.koin.androidx.compose.getViewModel
 import org.koin.core.parameter.parametersOf
+import kotlin.math.max
 
 @ExperimentalFoundationApi
 @ExperimentalAnimationApi
@@ -494,7 +495,6 @@ private fun WorkoutInProgressContent(
                                 )
                             }
                         }
-                        var workingSetIndex = 0
                         setGroup.sets.forEachIndexed { index, set ->
                             key(set.workoutSetId) {
                                 val dismissState = rememberDismissState()
@@ -517,7 +517,16 @@ private fun WorkoutInProgressContent(
                                             ) {
                                                 SetTypeBadge(
                                                     isWarmup = set.isWarmup,
-                                                    index = if (set.isWarmup) workingSetIndex else workingSetIndex++,
+                                                    index = if (set.isWarmup) {
+                                                        0
+                                                    } else {
+                                                        max(
+                                                            setGroup.sets
+                                                                .take(index + 1)
+                                                                .count { !it.isWarmup } - 1,
+                                                            0
+                                                        )
+                                                    },
                                                     modifier = Modifier
                                                         .padding(3.dp)
                                                         .width(WarmupIndicatorWidth),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -173,13 +173,16 @@
     <string name="dialog_body_rest_timer">Completed timers will not be affected. Durations will be saved for next time.</string>
     <string name="rest_timer_warmup_field">Warm-up sets</string>
     <string name="rest_timer_working_field">Working sets</string>
-    <string name="rest_timer_hint_none">Leave blank to disable the timer.</string>
+    <string name="rest_timer_hint_none">Set the duration to 0:00 to disable the timer.</string>
     <string name="dialog_confirm_rest_timer">Save timers</string>
     <string name="dialog_remove_rest_timer">Remove rest timers</string>
     <string name="rest_timer_indicator_warmup">Warm-up rest</string>
     <string name="rest_timer_indicator_working">Set rest</string>
     <string name="rest_timer_minus_30">-30s</string>
     <string name="rest_timer_plus_30">+30s</string>
+    <string name="rest_timer_icon_description">Rest timers. Warm-up: %1$s. Working: %2$s.</string>
+    <string name="rest_timer_increase">Increase rest duration</string>
+    <string name="rest_timer_decrease">Decrease rest duration</string>
     <string name="rest_timer_notification_running_title">Rest timer</string>
     <string name="rest_timer_notification_running_body">%1$s • %2$s remaining</string>
     <string name="rest_timer_notification_complete_title">Rest is over</string>


### PR DESCRIPTION
## Summary
- replace the routine editor rest timer summary with a compact icon button and redesign the dialog with button-based duration controls
- indicate saved rest timers via icon tinting and refresh copy for disabling timers
- fix working-set numbering during rest countdowns and trigger manual sound/vibration feedback when timers finish

## Testing
- ./gradlew assembleDebug --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e687945c4c832486a1448ea9c900f8