### PR TITLE
Fix rest timer crash and enable workout timer editing

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,8 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.VIBRATE" />
+
     <application
         android:name=".GymRoutinesApplication"
         android:allowBackup="false"

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/components/RestTimerControls.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/components/RestTimerControls.kt
@@ -1,0 +1,240 @@
+/*
+ * Splitfit
+ * Copyright (C) 2020  Noah Jutz
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.noahjutz.gymroutines.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.AlertDialog
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Remove
+import androidx.compose.material.icons.filled.Timer
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.noahjutz.gymroutines.R
+import com.noahjutz.gymroutines.util.MAX_REST_TIMER_SECONDS
+import com.noahjutz.gymroutines.util.REST_TIMER_STEP_SECONDS
+import com.noahjutz.gymroutines.util.formatRestDuration
+
+@Composable
+fun RestTimerDialog(
+    initialWarmupSeconds: Int,
+    initialWorkingSeconds: Int,
+    onDismiss: () -> Unit,
+    onConfirm: (Int, Int) -> Unit,
+    onRemove: () -> Unit,
+) {
+    var warmupSeconds by rememberSaveable(initialWarmupSeconds) {
+        mutableStateOf(initialWarmupSeconds.coerceIn(0, MAX_REST_TIMER_SECONDS))
+    }
+    var workingSeconds by rememberSaveable(initialWorkingSeconds) {
+        mutableStateOf(
+            initialWorkingSeconds.takeIf { it > 0 }
+                ?.coerceIn(0, MAX_REST_TIMER_SECONDS)
+                ?: 120
+        )
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.dialog_title_rest_timer)) },
+        text = {
+            Column {
+                Text(stringResource(R.string.dialog_body_rest_timer))
+                Spacer(Modifier.height(16.dp))
+                RestTimerDurationPicker(
+                    label = stringResource(R.string.rest_timer_warmup_field),
+                    seconds = warmupSeconds,
+                    onSecondsChange = { warmupSeconds = it.coerceIn(0, MAX_REST_TIMER_SECONDS) },
+                    showNonePlaceholder = true,
+                )
+                Spacer(Modifier.height(12.dp))
+                RestTimerDurationPicker(
+                    label = stringResource(R.string.rest_timer_working_field),
+                    seconds = workingSeconds,
+                    onSecondsChange = { workingSeconds = it.coerceIn(0, MAX_REST_TIMER_SECONDS) },
+                )
+                Spacer(Modifier.height(12.dp))
+                Text(
+                    text = stringResource(R.string.rest_timer_hint_none),
+                    style = MaterialTheme.typography.caption,
+                    color = MaterialTheme.colors.onSurface.copy(alpha = 0.6f)
+                )
+                if (initialWarmupSeconds > 0 || initialWorkingSeconds > 0) {
+                    Spacer(Modifier.height(12.dp))
+                    TextButton(onClick = onRemove) {
+                        Text(stringResource(R.string.dialog_remove_rest_timer))
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { onConfirm(warmupSeconds, workingSeconds) }
+            ) {
+                Text(stringResource(R.string.dialog_confirm_rest_timer))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.btn_cancel))
+            }
+        }
+    )
+}
+
+@Composable
+fun RestTimerDurationPicker(
+    label: String,
+    seconds: Int,
+    onSecondsChange: (Int) -> Unit,
+    showNonePlaceholder: Boolean = false,
+) {
+    val colors = MaterialTheme.colors
+    Column {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.subtitle2,
+            color = colors.onSurface
+        )
+        Spacer(Modifier.height(6.dp))
+        Row(
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(
+                onClick = {
+                    onSecondsChange((seconds - REST_TIMER_STEP_SECONDS).coerceAtLeast(0))
+                },
+                enabled = seconds > 0
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Remove,
+                    contentDescription = stringResource(R.string.rest_timer_decrease)
+                )
+            }
+            Surface(
+                modifier = Modifier
+                    .padding(horizontal = 4.dp)
+                    .defaultMinSize(minWidth = 96.dp)
+                    .heightIn(min = 44.dp),
+                shape = MaterialTheme.shapes.medium,
+                color = colors.onSurface.copy(alpha = 0.05f)
+            ) {
+                Box(
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    val labelText = when {
+                        seconds > 0 -> formatRestDuration(seconds)
+                        showNonePlaceholder -> stringResource(R.string.rest_timer_none)
+                        else -> formatRestDuration(seconds)
+                    }
+                    Text(
+                        text = labelText,
+                        style = MaterialTheme.typography.subtitle1,
+                        color = colors.onSurface
+                    )
+                }
+            }
+            IconButton(
+                onClick = {
+                    onSecondsChange((seconds + REST_TIMER_STEP_SECONDS).coerceAtMost(MAX_REST_TIMER_SECONDS))
+                }
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Add,
+                    contentDescription = stringResource(R.string.rest_timer_increase)
+                )
+            }
+        }
+        Spacer(Modifier.height(4.dp))
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            TextButton(
+                onClick = {
+                    onSecondsChange((seconds - 30).coerceAtLeast(0))
+                },
+                enabled = seconds > 0
+            ) {
+                Text(stringResource(R.string.rest_timer_minus_30))
+            }
+            TextButton(
+                onClick = {
+                    onSecondsChange((seconds + 30).coerceAtMost(MAX_REST_TIMER_SECONDS))
+                }
+            ) {
+                Text(stringResource(R.string.rest_timer_plus_30))
+            }
+        }
+    }
+}
+
+@Composable
+fun RestTimerIconButton(
+    hasRestTimers: Boolean,
+    warmupSeconds: Int,
+    workingSeconds: Int,
+    onClick: () -> Unit,
+) {
+    val colors = MaterialTheme.colors
+    val warmupText = if (warmupSeconds > 0) {
+        formatRestDuration(warmupSeconds)
+    } else {
+        stringResource(R.string.rest_timer_none)
+    }
+    val workingText = if (workingSeconds > 0) {
+        formatRestDuration(workingSeconds)
+    } else {
+        stringResource(R.string.rest_timer_none)
+    }
+    val tint = if (hasRestTimers) colors.primary else colors.onSurface.copy(alpha = 0.6f)
+    IconButton(onClick = onClick) {
+        Icon(
+            imageVector = Icons.Default.Timer,
+            contentDescription = stringResource(
+                R.string.rest_timer_icon_description,
+                warmupText,
+                workingText
+            ),
+            tint = tint
+        )
+    }
+}

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/routines/editor/RoutineEditor.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/routines/editor/RoutineEditor.kt
@@ -32,7 +32,6 @@ import androidx.compose.material.MaterialTheme.typography
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.runtime.*
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.SolidColor
@@ -49,17 +48,17 @@ import com.noahjutz.gymroutines.data.domain.Routine
 import com.noahjutz.gymroutines.data.domain.RoutineSetGroupWithSets
 import com.noahjutz.gymroutines.ui.components.AutoSelectTextField
 import com.noahjutz.gymroutines.ui.components.EditExerciseNotesDialog
+import com.noahjutz.gymroutines.ui.components.RestTimerDialog
+import com.noahjutz.gymroutines.ui.components.RestTimerIconButton
 import com.noahjutz.gymroutines.ui.components.SetTypeBadge
 import com.noahjutz.gymroutines.ui.components.SwipeToDeleteBackground
 import com.noahjutz.gymroutines.ui.components.TopBar
 import com.noahjutz.gymroutines.ui.components.WarmupIndicatorWidth
 import com.noahjutz.gymroutines.ui.components.durationVisualTransformation
 import com.noahjutz.gymroutines.util.RegexPatterns
-import com.noahjutz.gymroutines.util.durationDigitsToSeconds
-import com.noahjutz.gymroutines.util.formatRestDuration
 import com.noahjutz.gymroutines.util.formatSimple
-import com.noahjutz.gymroutines.util.secondsToDurationDigits
 import com.noahjutz.gymroutines.util.toStringOrBlank
+import kotlin.math.max
 import org.koin.androidx.compose.getViewModel
 import org.koin.core.parameter.parametersOf
 import kotlinx.coroutines.launch
@@ -127,139 +126,6 @@ fun RoutineEditor(
             }
         }
     }
-}
-
-@Composable
-private fun RestTimerSummary(
-    modifier: Modifier = Modifier,
-    warmupSeconds: Int,
-    workingSeconds: Int,
-    onEdit: () -> Unit,
-) {
-    val colors = MaterialTheme.colors
-    val warmupText = if (warmupSeconds > 0) {
-        formatRestDuration(warmupSeconds)
-    } else {
-        stringResource(R.string.rest_timer_none)
-    }
-    val workingText = if (workingSeconds > 0) {
-        formatRestDuration(workingSeconds)
-    } else {
-        stringResource(R.string.rest_timer_none)
-    }
-
-    Surface(
-        modifier = modifier,
-        shape = MaterialTheme.shapes.medium,
-        color = colors.primary.copy(alpha = 0.08f)
-    ) {
-        Row(
-            modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Icon(
-                imageVector = Icons.Default.Timer,
-                contentDescription = null,
-                tint = colors.primary
-            )
-            Spacer(Modifier.width(12.dp))
-            Column(Modifier.weight(1f)) {
-                Text(
-                    text = stringResource(R.string.rest_timer_label_warmup, warmupText),
-                    style = typography.body2,
-                    color = colors.onSurface
-                )
-                Spacer(Modifier.height(4.dp))
-                Text(
-                    text = stringResource(R.string.rest_timer_label_working, workingText),
-                    style = typography.body2,
-                    color = colors.onSurface
-                )
-            }
-            TextButton(onClick = onEdit) {
-                Text(stringResource(R.string.rest_timer_edit))
-            }
-        }
-    }
-}
-
-@Composable
-private fun RestTimerDialog(
-    initialWarmupSeconds: Int,
-    initialWorkingSeconds: Int,
-    onDismiss: () -> Unit,
-    onConfirm: (Int, Int) -> Unit,
-    onRemove: () -> Unit,
-) {
-    var warmupValue by rememberSaveable(initialWarmupSeconds) {
-        mutableStateOf(secondsToDurationDigits(initialWarmupSeconds))
-    }
-    var workingValue by rememberSaveable(initialWorkingSeconds) {
-        mutableStateOf(
-            secondsToDurationDigits(initialWorkingSeconds).ifBlank { secondsToDurationDigits(120) }
-        )
-    }
-
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(stringResource(R.string.dialog_title_rest_timer)) },
-        text = {
-            Column {
-                Text(stringResource(R.string.dialog_body_rest_timer))
-                Spacer(Modifier.height(16.dp))
-                OutlinedTextField(
-                    value = warmupValue,
-                    onValueChange = {
-                        if (it.matches(RegexPatterns.duration)) warmupValue = it
-                    },
-                    label = { Text(stringResource(R.string.rest_timer_warmup_field)) },
-                    placeholder = { Text(stringResource(R.string.rest_timer_none)) },
-                    visualTransformation = durationVisualTransformation,
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                    singleLine = true,
-                )
-                Spacer(Modifier.height(12.dp))
-                OutlinedTextField(
-                    value = workingValue,
-                    onValueChange = {
-                        if (it.matches(RegexPatterns.duration)) workingValue = it
-                    },
-                    label = { Text(stringResource(R.string.rest_timer_working_field)) },
-                    visualTransformation = durationVisualTransformation,
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                    singleLine = true,
-                )
-                Spacer(Modifier.height(12.dp))
-                Text(
-                    text = stringResource(R.string.rest_timer_hint_none),
-                    style = typography.caption,
-                    color = MaterialTheme.colors.onSurface.copy(alpha = 0.6f)
-                )
-                if (initialWarmupSeconds > 0 || initialWorkingSeconds > 0) {
-                    Spacer(Modifier.height(12.dp))
-                    TextButton(onClick = onRemove) {
-                        Text(stringResource(R.string.dialog_remove_rest_timer))
-                    }
-                }
-            }
-        },
-        confirmButton = {
-            TextButton(
-                onClick = {
-                    val warmupSeconds = durationDigitsToSeconds(warmupValue)
-                    val workingSeconds = durationDigitsToSeconds(workingValue)
-                    onConfirm(warmupSeconds, workingSeconds)
-                }
-            ) {
-                Text(stringResource(R.string.dialog_confirm_rest_timer))
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text(stringResource(R.string.btn_cancel))
-            }
-        }
-    )
 }
 
 @Composable
@@ -484,90 +350,82 @@ private fun RoutineEditorContent(
                         }
                     }
                     val trimmedNotes = remember(exercise.notes) { exercise.notes.trim() }
-                        if (trimmedNotes.isNotEmpty()) {
-                            Surface(
-                                modifier = Modifier
-                                    .padding(horizontal = 16.dp, vertical = 6.dp)
-                                    .fillMaxWidth(),
+                    val warmupRest = setGroup.group.restTimerWarmupSeconds
+                    val workingRest = setGroup.group.restTimerWorkingSeconds
+                    val hasRestTimers = warmupRest > 0 || workingRest > 0
+                    val restTimerButton: @Composable () -> Unit = {
+                        RestTimerIconButton(
+                            hasRestTimers = hasRestTimers,
+                            warmupSeconds = warmupRest,
+                            workingSeconds = workingRest,
+                            onClick = { restTimerEditorGroup = setGroup }
+                        )
+                    }
+                    if (trimmedNotes.isNotEmpty()) {
+                        Surface(
+                            modifier = Modifier
+                                .padding(horizontal = 16.dp, vertical = 6.dp)
+                                .fillMaxWidth(),
                             color = colors.primary.copy(alpha = 0.08f),
                             shape = RoundedCornerShape(16.dp)
                         ) {
-                                Row(
-                                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp),
+                            Row(
+                                modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp),
                                 verticalAlignment = Alignment.CenterVertically
                             ) {
-                                Icon(
-                                    imageVector = Icons.Default.Edit,
-                                    contentDescription = stringResource(R.string.label_exercise_notes),
-                                    tint = colors.primary
-                                )
-                                Spacer(Modifier.width(12.dp))
                                 Text(
                                     text = trimmedNotes,
                                     style = typography.body2,
                                     color = colors.onSurface.copy(alpha = 0.9f),
                                     modifier = Modifier.weight(1f)
                                 )
-                                IconButton(
-                                    onClick = {
-                                        notesEditorState = ExerciseNotesDialogState(
-                                            exerciseId = exercise.exerciseId,
-                                            name = exercise.name,
-                                            notes = exercise.notes
+                                Row(
+                                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    IconButton(
+                                        onClick = {
+                                            notesEditorState = ExerciseNotesDialogState(
+                                                exerciseId = exercise.exerciseId,
+                                                name = exercise.name,
+                                                notes = exercise.notes
+                                            )
+                                        }
+                                    ) {
+                                        Icon(
+                                            imageVector = Icons.Default.Edit,
+                                            contentDescription = stringResource(R.string.btn_edit_notes),
+                                            tint = colors.primary
                                         )
                                     }
-                                ) {
-                                    Icon(
-                                        imageVector = Icons.Default.Edit,
-                                        contentDescription = stringResource(R.string.btn_edit_notes),
-                                        tint = colors.primary
-                                    )
+                                    restTimerButton()
                                 }
                             }
                         }
                     } else {
-                        TextButton(
+                        Row(
                             modifier = Modifier
-                                .padding(horizontal = 12.dp, vertical = 4.dp),
-                            onClick = {
-                                notesEditorState = ExerciseNotesDialogState(
-                                    exerciseId = exercise.exerciseId,
-                                    name = exercise.name,
-                                    notes = exercise.notes
-                                )
-                            }
+                                .padding(horizontal = 12.dp, vertical = 4.dp)
+                                .fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically
                         ) {
-                            Icon(imageVector = Icons.Default.Edit, contentDescription = null)
-                            Spacer(Modifier.width(8.dp))
-                            Text(stringResource(R.string.btn_add_notes))
+                            TextButton(
+                                modifier = Modifier.weight(1f),
+                                onClick = {
+                                    notesEditorState = ExerciseNotesDialogState(
+                                        exerciseId = exercise.exerciseId,
+                                        name = exercise.name,
+                                        notes = exercise.notes
+                                    )
+                                }
+                            ) {
+                                Text(stringResource(R.string.btn_add_notes))
+                            }
+                            restTimerButton()
                         }
                     }
                     Column(Modifier.padding(vertical = 12.dp, horizontal = 8.dp)) {
-                        val warmupRest = setGroup.group.restTimerWarmupSeconds
-                        val workingRest = setGroup.group.restTimerWorkingSeconds
-                        val hasRestTimers = warmupRest > 0 || workingRest > 0
-
-                        if (hasRestTimers) {
-                            RestTimerSummary(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(horizontal = 4.dp, vertical = 6.dp),
-                                warmupSeconds = warmupRest,
-                                workingSeconds = workingRest,
-                                onEdit = { restTimerEditorGroup = setGroup }
-                            )
-                        } else {
-                            TextButton(
-                                modifier = Modifier
-                                    .padding(horizontal = 4.dp, vertical = 6.dp),
-                                onClick = { restTimerEditorGroup = setGroup }
-                            ) {
-                                Icon(imageVector = Icons.Default.Timer, contentDescription = null)
-                                Spacer(Modifier.width(8.dp))
-                                Text(stringResource(R.string.rest_timer_add))
-                            }
-                        }
-
+                        Spacer(Modifier.height(4.dp))
                         Divider(
                             modifier = Modifier
                                 .padding(horizontal = 8.dp, vertical = 4.dp),
@@ -631,7 +489,6 @@ private fun RoutineEditorContent(
                                 )
                             }
                         }
-                        var workingSetIndex = 0
                         setGroup.sets.forEachIndexed { index, set ->
                             key(set.routineSetId) {
                                 val dismissState = rememberDismissState()
@@ -646,7 +503,16 @@ private fun RoutineEditorContent(
                                         ) {
                                             SetTypeBadge(
                                                 isWarmup = set.isWarmup,
-                                                index = if (set.isWarmup) workingSetIndex else workingSetIndex++,
+                                                index = if (set.isWarmup) {
+                                                    0
+                                                } else {
+                                                    max(
+                                                        setGroup.sets
+                                                            .take(index + 1)
+                                                            .count { !it.isWarmup } - 1,
+                                                        0
+                                                    )
+                                                },
                                                 modifier = Modifier
                                                     .padding(3.dp)
                                                     .width(WarmupIndicatorWidth),

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/workout/in_progress/WorkoutInProgress.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/workout/in_progress/WorkoutInProgress.kt
@@ -78,19 +78,22 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.graphics.lerp
 import com.noahjutz.gymroutines.R
 import com.noahjutz.gymroutines.data.domain.WorkoutSet
+import com.noahjutz.gymroutines.data.domain.WorkoutSetGroupWithSets
 import com.noahjutz.gymroutines.data.domain.WorkoutWithSetGroups
 import com.noahjutz.gymroutines.data.domain.duration
 import com.noahjutz.gymroutines.ui.components.AutoSelectTextField
 import com.noahjutz.gymroutines.ui.components.EditExerciseNotesDialog
+import com.noahjutz.gymroutines.ui.components.RestTimerDialog
+import com.noahjutz.gymroutines.ui.components.RestTimerIconButton
 import com.noahjutz.gymroutines.ui.components.SetTypeBadge
 import com.noahjutz.gymroutines.ui.components.SwipeToDeleteBackground
 import com.noahjutz.gymroutines.ui.components.TopBar
@@ -103,6 +106,7 @@ import com.noahjutz.gymroutines.util.pretty
 import com.noahjutz.gymroutines.util.toStringOrBlank
 import org.koin.androidx.compose.getViewModel
 import org.koin.core.parameter.parametersOf
+import kotlin.math.max
 
 @ExperimentalFoundationApi
 @ExperimentalAnimationApi
@@ -215,6 +219,23 @@ private fun WorkoutInProgressContent(
             onConfirm = { updatedNotes ->
                 viewModel.updateExerciseNotes(state.exerciseId, updatedNotes)
                 notesEditorState = null
+            }
+        )
+    }
+
+    var restTimerEditorGroup by remember { mutableStateOf<WorkoutSetGroupWithSets?>(null) }
+    restTimerEditorGroup?.let { group ->
+        RestTimerDialog(
+            initialWarmupSeconds = group.group.restTimerWarmupSeconds,
+            initialWorkingSeconds = group.group.restTimerWorkingSeconds,
+            onDismiss = { restTimerEditorGroup = null },
+            onConfirm = { warmupSeconds, workingSeconds ->
+                viewModel.updateRestTimers(group.group.id, warmupSeconds, workingSeconds)
+                restTimerEditorGroup = null
+            },
+            onRemove = {
+                viewModel.updateRestTimers(group.group.id, 0, 0)
+                restTimerEditorGroup = null
             }
         )
     }
@@ -341,6 +362,17 @@ private fun WorkoutInProgressContent(
 
                     if (exercise != null) {
                         val trimmedNotes = remember(exercise.notes) { exercise.notes.trim() }
+                        val warmupRest = setGroup.group.restTimerWarmupSeconds
+                        val workingRest = setGroup.group.restTimerWorkingSeconds
+                        val hasRestTimers = warmupRest > 0 || workingRest > 0
+                        val restTimerButton: @Composable () -> Unit = {
+                            RestTimerIconButton(
+                                hasRestTimers = hasRestTimers,
+                                warmupSeconds = warmupRest,
+                                workingSeconds = workingRest,
+                                onClick = { restTimerEditorGroup = setGroup }
+                            )
+                        }
                         if (trimmedNotes.isNotEmpty()) {
                             Surface(
                                 modifier = Modifier
@@ -353,50 +385,55 @@ private fun WorkoutInProgressContent(
                                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp),
                                     verticalAlignment = Alignment.CenterVertically
                                 ) {
-                                    Icon(
-                                        imageVector = Icons.Default.Edit,
-                                        contentDescription = stringResource(R.string.label_exercise_notes),
-                                        tint = colors.primary
-                                    )
-                                    Spacer(Modifier.width(12.dp))
                                     Text(
                                         text = trimmedNotes,
                                         style = typography.body2,
                                         color = colors.onSurface.copy(alpha = 0.9f),
                                         modifier = Modifier.weight(1f)
                                     )
-                                    IconButton(
-                                        onClick = {
-                                            notesEditorState = ExerciseNotesDialogState(
-                                                exerciseId = exercise.exerciseId,
-                                                name = exercise.name,
-                                                notes = exercise.notes
+                                    Row(
+                                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                                        verticalAlignment = Alignment.CenterVertically
+                                    ) {
+                                        IconButton(
+                                            onClick = {
+                                                notesEditorState = ExerciseNotesDialogState(
+                                                    exerciseId = exercise.exerciseId,
+                                                    name = exercise.name,
+                                                    notes = exercise.notes
+                                                )
+                                            }
+                                        ) {
+                                            Icon(
+                                                imageVector = Icons.Default.Edit,
+                                                contentDescription = stringResource(R.string.btn_edit_notes),
+                                                tint = colors.primary
                                             )
                                         }
-                                    ) {
-                                        Icon(
-                                            imageVector = Icons.Default.Edit,
-                                            contentDescription = stringResource(R.string.btn_edit_notes),
-                                            tint = colors.primary
-                                        )
+                                        restTimerButton()
                                     }
                                 }
                             }
                         } else {
-                            TextButton(
+                            Row(
                                 modifier = Modifier
-                                    .padding(horizontal = 12.dp, vertical = 4.dp),
-                                onClick = {
-                                    notesEditorState = ExerciseNotesDialogState(
-                                        exerciseId = exercise.exerciseId,
-                                        name = exercise.name,
-                                        notes = exercise.notes
-                                    )
-                                }
+                                    .padding(horizontal = 12.dp, vertical = 4.dp)
+                                    .fillMaxWidth(),
+                                verticalAlignment = Alignment.CenterVertically
                             ) {
-                                Icon(imageVector = Icons.Default.Edit, contentDescription = null)
-                                Spacer(Modifier.width(8.dp))
-                                Text(stringResource(R.string.btn_add_notes))
+                                TextButton(
+                                    modifier = Modifier.weight(1f),
+                                    onClick = {
+                                        notesEditorState = ExerciseNotesDialogState(
+                                            exerciseId = exercise.exerciseId,
+                                            name = exercise.name,
+                                            notes = exercise.notes
+                                        )
+                                    }
+                                ) {
+                                    Text(stringResource(R.string.btn_add_notes))
+                                }
+                                restTimerButton()
                             }
                         }
                     }
@@ -494,7 +531,6 @@ private fun WorkoutInProgressContent(
                                 )
                             }
                         }
-                        var workingSetIndex = 0
                         setGroup.sets.forEachIndexed { index, set ->
                             key(set.workoutSetId) {
                                 val dismissState = rememberDismissState()
@@ -517,7 +553,16 @@ private fun WorkoutInProgressContent(
                                             ) {
                                                 SetTypeBadge(
                                                     isWarmup = set.isWarmup,
-                                                    index = if (set.isWarmup) workingSetIndex else workingSetIndex++,
+                                                    index = if (set.isWarmup) {
+                                                        0
+                                                    } else {
+                                                        max(
+                                                            setGroup.sets
+                                                                .take(index + 1)
+                                                                .count { !it.isWarmup } - 1,
+                                                            0
+                                                        )
+                                                    },
                                                     modifier = Modifier
                                                         .padding(3.dp)
                                                         .width(WarmupIndicatorWidth),

--- a/app/src/main/java/com/noahjutz/gymroutines/util/RestTimerDefaults.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/util/RestTimerDefaults.kt
@@ -1,0 +1,22 @@
+/*
+ * Splitfit
+ * Copyright (C) 2020  Noah Jutz
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.noahjutz.gymroutines.util
+
+const val MAX_REST_TIMER_SECONDS = 99 * 60 + 59
+const val REST_TIMER_STEP_SECONDS = 15

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -173,13 +173,16 @@
     <string name="dialog_body_rest_timer">Completed timers will not be affected. Durations will be saved for next time.</string>
     <string name="rest_timer_warmup_field">Warm-up sets</string>
     <string name="rest_timer_working_field">Working sets</string>
-    <string name="rest_timer_hint_none">Leave blank to disable the timer.</string>
+    <string name="rest_timer_hint_none">Set the duration to 0:00 to disable the timer.</string>
     <string name="dialog_confirm_rest_timer">Save timers</string>
     <string name="dialog_remove_rest_timer">Remove rest timers</string>
     <string name="rest_timer_indicator_warmup">Warm-up rest</string>
     <string name="rest_timer_indicator_working">Set rest</string>
     <string name="rest_timer_minus_30">-30s</string>
     <string name="rest_timer_plus_30">+30s</string>
+    <string name="rest_timer_icon_description">Rest timers. Warm-up: %1$s. Working: %2$s.</string>
+    <string name="rest_timer_increase">Increase rest duration</string>
+    <string name="rest_timer_decrease">Decrease rest duration</string>
     <string name="rest_timer_notification_running_title">Rest timer</string>
     <string name="rest_timer_notification_running_body">%1$s • %2$s remaining</string>
     <string name="rest_timer_notification_complete_title">Rest is over</string>


### PR DESCRIPTION
## Summary
- add shared rest timer dialog and icon components plus shared timer constants for reuse
- remove duplicate note icons, wire the workout screen to launch the timer dialog, and keep active timers in sync with edits
- request vibration permission so rest timer feedback no longer crashes when a timer completes

## Testing
- ./gradlew assembleDebug --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e687945c4c832486a1448ea9c900f8