### PR TITLE
Improve rest timer controls in workout screens

### DIFF
--- a/app/src/main/java/com/noahjutz/gymroutines/ui/components/RestTimerDialog.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/components/RestTimerDialog.kt
@@ -1,0 +1,172 @@
+package com.noahjutz.gymroutines.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material.AlertDialog
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Remove
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.noahjutz.gymroutines.R
+import com.noahjutz.gymroutines.util.formatRestDuration
+
+private const val MAX_REST_SECONDS = 99 * 60 + 59
+
+@Composable
+fun RestTimerDialog(
+    initialWarmupSeconds: Int,
+    initialWorkingSeconds: Int,
+    onDismiss: () -> Unit,
+    onConfirm: (Int, Int) -> Unit,
+    onRemove: (() -> Unit)? = null,
+) {
+    var warmupSeconds by rememberSaveable(initialWarmupSeconds) {
+        mutableStateOf(initialWarmupSeconds.coerceIn(0, MAX_REST_SECONDS))
+    }
+    var workingSeconds by rememberSaveable(initialWorkingSeconds) {
+        mutableStateOf(initialWorkingSeconds.coerceIn(0, MAX_REST_SECONDS))
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.dialog_title_rest_timer)) },
+        text = {
+            Column {
+                Text(stringResource(R.string.dialog_body_rest_timer))
+                Spacer(Modifier.height(16.dp))
+                RestTimerValueAdjuster(
+                    label = stringResource(R.string.rest_timer_warmup_field),
+                    seconds = warmupSeconds,
+                    onSecondsChange = { warmupSeconds = it.coerceIn(0, MAX_REST_SECONDS) }
+                )
+                Spacer(Modifier.height(12.dp))
+                RestTimerValueAdjuster(
+                    label = stringResource(R.string.rest_timer_working_field),
+                    seconds = workingSeconds,
+                    onSecondsChange = { workingSeconds = it.coerceIn(0, MAX_REST_SECONDS) }
+                )
+                if (onRemove != null && (initialWarmupSeconds > 0 || initialWorkingSeconds > 0)) {
+                    Spacer(Modifier.height(12.dp))
+                    TextButton(onClick = onRemove) {
+                        Text(stringResource(R.string.dialog_remove_rest_timer))
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { onConfirm(warmupSeconds, workingSeconds) }
+            ) {
+                Text(stringResource(R.string.dialog_confirm_rest_timer))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.btn_cancel))
+            }
+        }
+    )
+}
+
+@Composable
+private fun RestTimerValueAdjuster(
+    label: String,
+    seconds: Int,
+    onSecondsChange: (Int) -> Unit,
+) {
+    Column(Modifier.fillMaxWidth()) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.subtitle2.copy(fontWeight = FontWeight.SemiBold),
+            color = MaterialTheme.colors.onSurface
+        )
+        Spacer(Modifier.height(8.dp))
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+            shape = MaterialTheme.shapes.medium,
+            color = MaterialTheme.colors.onSurface.copy(alpha = 0.05f)
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                IconButton(
+                    onClick = { onSecondsChange((seconds - 5).coerceAtLeast(0)) },
+                    enabled = seconds > 0
+                ) {
+                    Icon(Icons.Default.Remove, contentDescription = null)
+                }
+                Text(
+                    text = formatRestDuration(seconds),
+                    modifier = Modifier.widthIn(min = 72.dp),
+                    style = MaterialTheme.typography.h6,
+                    textAlign = TextAlign.Center
+                )
+                IconButton(
+                    onClick = { onSecondsChange((seconds + 5).coerceAtMost(MAX_REST_SECONDS)) }
+                ) {
+                    Icon(Icons.Default.Add, contentDescription = null)
+                }
+            }
+        }
+        Spacer(Modifier.height(8.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            RestTimerQuickAdjustButton(
+                label = stringResource(R.string.rest_timer_minus_30),
+                enabled = seconds > 0,
+                onClick = { onSecondsChange((seconds - 30).coerceAtLeast(0)) }
+            )
+            RestTimerQuickAdjustButton(
+                label = stringResource(R.string.rest_timer_plus_30),
+                onClick = { onSecondsChange((seconds + 30).coerceAtMost(MAX_REST_SECONDS)) }
+            )
+            RestTimerQuickAdjustButton(
+                label = stringResource(R.string.rest_timer_plus_minute),
+                onClick = { onSecondsChange((seconds + 60).coerceAtMost(MAX_REST_SECONDS)) }
+            )
+        }
+    }
+}
+
+@Composable
+private fun RestTimerQuickAdjustButton(
+    label: String,
+    enabled: Boolean = true,
+    onClick: () -> Unit,
+) {
+    TextButton(
+        onClick = onClick,
+        enabled = enabled,
+        contentPadding = PaddingValues(horizontal = 12.dp, vertical = 6.dp)
+    ) {
+        Text(label)
+    }
+}

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/routines/editor/RoutineEditor.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/routines/editor/RoutineEditor.kt
@@ -32,7 +32,6 @@ import androidx.compose.material.MaterialTheme.typography
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.runtime.*
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.SolidColor
@@ -49,16 +48,15 @@ import com.noahjutz.gymroutines.data.domain.Routine
 import com.noahjutz.gymroutines.data.domain.RoutineSetGroupWithSets
 import com.noahjutz.gymroutines.ui.components.AutoSelectTextField
 import com.noahjutz.gymroutines.ui.components.EditExerciseNotesDialog
+import com.noahjutz.gymroutines.ui.components.RestTimerDialog
 import com.noahjutz.gymroutines.ui.components.SetTypeBadge
 import com.noahjutz.gymroutines.ui.components.SwipeToDeleteBackground
 import com.noahjutz.gymroutines.ui.components.TopBar
 import com.noahjutz.gymroutines.ui.components.WarmupIndicatorWidth
 import com.noahjutz.gymroutines.ui.components.durationVisualTransformation
 import com.noahjutz.gymroutines.util.RegexPatterns
-import com.noahjutz.gymroutines.util.durationDigitsToSeconds
 import com.noahjutz.gymroutines.util.formatRestDuration
 import com.noahjutz.gymroutines.util.formatSimple
-import com.noahjutz.gymroutines.util.secondsToDurationDigits
 import com.noahjutz.gymroutines.util.toStringOrBlank
 import org.koin.androidx.compose.getViewModel
 import org.koin.core.parameter.parametersOf
@@ -181,85 +179,6 @@ private fun RestTimerSummary(
             }
         }
     }
-}
-
-@Composable
-private fun RestTimerDialog(
-    initialWarmupSeconds: Int,
-    initialWorkingSeconds: Int,
-    onDismiss: () -> Unit,
-    onConfirm: (Int, Int) -> Unit,
-    onRemove: () -> Unit,
-) {
-    var warmupValue by rememberSaveable(initialWarmupSeconds) {
-        mutableStateOf(secondsToDurationDigits(initialWarmupSeconds))
-    }
-    var workingValue by rememberSaveable(initialWorkingSeconds) {
-        mutableStateOf(
-            secondsToDurationDigits(initialWorkingSeconds).ifBlank { secondsToDurationDigits(120) }
-        )
-    }
-
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(stringResource(R.string.dialog_title_rest_timer)) },
-        text = {
-            Column {
-                Text(stringResource(R.string.dialog_body_rest_timer))
-                Spacer(Modifier.height(16.dp))
-                OutlinedTextField(
-                    value = warmupValue,
-                    onValueChange = {
-                        if (it.matches(RegexPatterns.duration)) warmupValue = it
-                    },
-                    label = { Text(stringResource(R.string.rest_timer_warmup_field)) },
-                    placeholder = { Text(stringResource(R.string.rest_timer_none)) },
-                    visualTransformation = durationVisualTransformation,
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                    singleLine = true,
-                )
-                Spacer(Modifier.height(12.dp))
-                OutlinedTextField(
-                    value = workingValue,
-                    onValueChange = {
-                        if (it.matches(RegexPatterns.duration)) workingValue = it
-                    },
-                    label = { Text(stringResource(R.string.rest_timer_working_field)) },
-                    visualTransformation = durationVisualTransformation,
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                    singleLine = true,
-                )
-                Spacer(Modifier.height(12.dp))
-                Text(
-                    text = stringResource(R.string.rest_timer_hint_none),
-                    style = typography.caption,
-                    color = MaterialTheme.colors.onSurface.copy(alpha = 0.6f)
-                )
-                if (initialWarmupSeconds > 0 || initialWorkingSeconds > 0) {
-                    Spacer(Modifier.height(12.dp))
-                    TextButton(onClick = onRemove) {
-                        Text(stringResource(R.string.dialog_remove_rest_timer))
-                    }
-                }
-            }
-        },
-        confirmButton = {
-            TextButton(
-                onClick = {
-                    val warmupSeconds = durationDigitsToSeconds(warmupValue)
-                    val workingSeconds = durationDigitsToSeconds(workingValue)
-                    onConfirm(warmupSeconds, workingSeconds)
-                }
-            ) {
-                Text(stringResource(R.string.dialog_confirm_rest_timer))
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text(stringResource(R.string.btn_cancel))
-            }
-        }
-    )
 }
 
 @Composable

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -180,6 +180,7 @@
     <string name="rest_timer_indicator_working">Set rest</string>
     <string name="rest_timer_minus_30">-30s</string>
     <string name="rest_timer_plus_30">+30s</string>
+    <string name="rest_timer_plus_minute">+1:00</string>
     <string name="rest_timer_notification_running_title">Rest timer</string>
     <string name="rest_timer_notification_running_body">%1$s • %2$s remaining</string>
     <string name="rest_timer_notification_complete_title">Rest is over</string>


### PR DESCRIPTION
## Summary
- replace the freeform rest timer inputs with a shared button-based `RestTimerDialog` component and use it in the routine editor
- allow adjusting rest timers from the active workout view, keep set numbering stable while timers tick, and restore the delete confirmation dialog
- add view-model support for persisting rest timer updates and a preset string for the +1:00 quick adjustment

## Testing
- ./gradlew assembleDebug --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e6b39e9404832496b82a9baa400f40