### PR TITLE
Handle exercise library load failures

### DIFF
--- a/app/src/main/java/com/noahjutz/gymroutines/data/library/ExerciseLibraryRepository.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/data/library/ExerciseLibraryRepository.kt
@@ -1,7 +1,9 @@
 package com.noahjutz.gymroutines.data.library
 
 import android.content.Context
+import android.util.Log
 import java.util.Locale
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -41,14 +43,36 @@ class ExerciseLibraryRepository(
 
     suspend fun loadLibrary() {
         withContext(dispatcher) {
-            val assets = context.assets
-            val exercisesJson = assets.open(EXERCISES_PATH).bufferedReader().use { it.readText() }
-            val exercises = json.decodeFromString(ListSerializer(LibraryExercise.serializer()), exercisesJson)
-            _exercises.value = exercises.sortedBy { it.name.lowercase(Locale.getDefault()) }
+            try {
+                val assets = context.assets
+                val exercisesJson =
+                    assets.open(EXERCISES_PATH).bufferedReader().use { it.readText() }
+                val exercises =
+                    json.decodeFromString(
+                        ListSerializer(LibraryExercise.serializer()),
+                        exercisesJson
+                    )
+                val sortedExercises =
+                    exercises.sortedBy { it.name.lowercase(Locale.getDefault()) }
+                _exercises.value = sortedExercises
 
-            _bodyParts.value = loadNamedValues(BODYPARTS_PATH, exercises.flatMap { it.bodyParts })
-            _equipments.value = loadNamedValues(EQUIPMENTS_PATH, exercises.flatMap { it.equipments })
-            _targetMuscles.value = loadNamedValues(MUSCLES_PATH, exercises.flatMap { it.targetMuscles + it.secondaryMuscles })
+                _bodyParts.value =
+                    loadNamedValues(BODYPARTS_PATH, sortedExercises.flatMap { it.bodyParts })
+                _equipments.value =
+                    loadNamedValues(EQUIPMENTS_PATH, sortedExercises.flatMap { it.equipments })
+                _targetMuscles.value = loadNamedValues(
+                    MUSCLES_PATH,
+                    sortedExercises.flatMap { it.targetMuscles + it.secondaryMuscles }
+                )
+            } catch (cancellationException: CancellationException) {
+                throw cancellationException
+            } catch (exception: Exception) {
+                Log.e(TAG, "Failed to load exercise library assets", exception)
+                _exercises.value = emptyList()
+                _bodyParts.value = emptyList()
+                _equipments.value = emptyList()
+                _targetMuscles.value = emptyList()
+            }
         }
     }
 
@@ -69,6 +93,7 @@ class ExerciseLibraryRepository(
     }
 
     companion object {
+        private const val TAG = "ExerciseLibraryRepo"
         private const val LIBRARY_DIR = "exercise_library"
         private const val EXERCISES_PATH = "$LIBRARY_DIR/exercises.json"
         private const val BODYPARTS_PATH = "$LIBRARY_DIR/bodyparts.json"


### PR DESCRIPTION
## Summary
- guard the exercise library asset load with error handling so parsing failures no longer crash the app
- log failures and reset repository state to keep downstream flows stable

## Testing
- ./gradlew assembleDebug --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e6cc204f388324ba87fb2bfaa20a64