### PR TITLE
Lazy load exercise library data to prevent startup crash

### DIFF
--- a/app/src/main/java/com/noahjutz/gymroutines/data/library/ExerciseLibraryRepository.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/data/library/ExerciseLibraryRepository.kt
@@ -3,18 +3,25 @@ package com.noahjutz.gymroutines.data.library
 import android.content.Context
 import android.util.Log
 import java.util.Locale
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import kotlin.jvm.Volatile
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromStream
 
 class ExerciseLibraryRepository(
     private val context: Context,
@@ -22,6 +29,10 @@ class ExerciseLibraryRepository(
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
     private val scope = CoroutineScope(SupervisorJob() + dispatcher)
+    private val loadMutex = Mutex()
+    private val hasLoaded = AtomicBoolean(false)
+    @Volatile
+    private var loadingJob: Job? = null
 
     private val _exercises = MutableStateFlow<List<LibraryExercise>>(emptyList())
     val exercises: StateFlow<List<LibraryExercise>> = _exercises.asStateFlow()
@@ -35,43 +46,59 @@ class ExerciseLibraryRepository(
     private val _targetMuscles = MutableStateFlow<List<String>>(emptyList())
     val targetMuscles: StateFlow<List<String>> = _targetMuscles.asStateFlow()
 
-    init {
-        scope.launch {
+    fun ensureLoaded() {
+        if (hasLoaded.get()) return
+        val currentJob = loadingJob
+        if (currentJob?.isActive == true) return
+        val job = scope.launch {
             loadLibrary()
         }
+        job.invokeOnCompletion {
+            if (loadingJob === job) {
+                loadingJob = null
+            }
+        }
+        loadingJob = job
     }
 
+    @OptIn(ExperimentalSerializationApi::class)
     suspend fun loadLibrary() {
+        if (hasLoaded.get()) return
         withContext(dispatcher) {
-            try {
-                val assets = context.assets
-                val exercisesJson =
-                    assets.open(EXERCISES_PATH).bufferedReader().use { it.readText() }
-                val exercises =
-                    json.decodeFromString(
-                        ListSerializer(LibraryExercise.serializer()),
-                        exercisesJson
-                    )
-                val sortedExercises =
-                    exercises.sortedBy { it.name.lowercase(Locale.getDefault()) }
-                _exercises.value = sortedExercises
+            if (hasLoaded.get()) return@withContext
+            loadMutex.withLock {
+                if (hasLoaded.get()) return@withLock
+                try {
+                    val assets = context.assets
+                    val exercises = assets.open(EXERCISES_PATH).use { stream ->
+                        json.decodeFromStream(
+                            ListSerializer(LibraryExercise.serializer()),
+                            stream
+                        )
+                    }
+                    val sortedExercises =
+                        exercises.sortedBy { it.name.lowercase(Locale.getDefault()) }
+                    _exercises.value = sortedExercises
 
-                _bodyParts.value =
-                    loadNamedValues(BODYPARTS_PATH, sortedExercises.flatMap { it.bodyParts })
-                _equipments.value =
-                    loadNamedValues(EQUIPMENTS_PATH, sortedExercises.flatMap { it.equipments })
-                _targetMuscles.value = loadNamedValues(
-                    MUSCLES_PATH,
-                    sortedExercises.flatMap { it.targetMuscles + it.secondaryMuscles }
-                )
-            } catch (cancellationException: CancellationException) {
-                throw cancellationException
-            } catch (exception: Exception) {
-                Log.e(TAG, "Failed to load exercise library assets", exception)
-                _exercises.value = emptyList()
-                _bodyParts.value = emptyList()
-                _equipments.value = emptyList()
-                _targetMuscles.value = emptyList()
+                    _bodyParts.value =
+                        loadNamedValues(BODYPARTS_PATH, sortedExercises.flatMap { it.bodyParts })
+                    _equipments.value =
+                        loadNamedValues(EQUIPMENTS_PATH, sortedExercises.flatMap { it.equipments })
+                    _targetMuscles.value = loadNamedValues(
+                        MUSCLES_PATH,
+                        sortedExercises.flatMap { it.targetMuscles + it.secondaryMuscles }
+                    )
+                    hasLoaded.set(true)
+                } catch (cancellationException: CancellationException) {
+                    throw cancellationException
+                } catch (throwable: Throwable) {
+                    Log.e(TAG, "Failed to load exercise library assets", throwable)
+                    _exercises.value = emptyList()
+                    _bodyParts.value = emptyList()
+                    _equipments.value = emptyList()
+                    _targetMuscles.value = emptyList()
+                    hasLoaded.set(false)
+                }
             }
         }
     }
@@ -80,11 +107,15 @@ class ExerciseLibraryRepository(
         return _exercises.value.firstOrNull { it.id == id }
     }
 
+    @OptIn(ExperimentalSerializationApi::class)
     private fun loadNamedValues(path: String, fallback: List<String>): List<String> {
         return try {
-            val text = context.assets.open(path).bufferedReader().use { it.readText() }
-            val values = json.decodeFromString(ListSerializer(LibraryNamedValue.serializer()), text)
-            values.map { it.name }
+            context.assets.open(path).use { stream ->
+                json.decodeFromStream(
+                    ListSerializer(LibraryNamedValue.serializer()),
+                    stream
+                )
+            }.map { it.name }
         } catch (_: Exception) {
             fallback
         }.mapNotNull { it.takeUnless(String::isBlank)?.trim() }

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/exercises/library/ExerciseLibraryViewModel.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/exercises/library/ExerciseLibraryViewModel.kt
@@ -53,6 +53,10 @@ class ExerciseLibraryViewModel(
 ) : ViewModel() {
     private val locale = Locale.getDefault()
 
+    init {
+        libraryRepository.ensureLoaded()
+    }
+
     private val _query = MutableStateFlow("")
     private val _selectedBodyPart = MutableStateFlow<String?>(null)
     private val _selectedEquipment = MutableStateFlow<String?>(null)

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/exercises/list/ExerciseListViewModel.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/exercises/list/ExerciseListViewModel.kt
@@ -47,6 +47,10 @@ class ExerciseListViewModel(
     private val _nameFilter = MutableStateFlow("")
     val nameFilter = _nameFilter.asStateFlow()
 
+    init {
+        libraryRepository.ensureLoaded()
+    }
+
     fun setNameFilter(filter: String) {
         _nameFilter.value = filter
     }


### PR DESCRIPTION
## Summary
- load exercise library assets on-demand behind a guarded coroutine instead of eagerly during application start
- parse large JSON assets via streams and cache named value lists while catching failures so the app can stay alive even if loading fails
- ensure exercise-related view models request the library to load when created so UI continues to function

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: Android SDK not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e6d09de810832493a8f2fd67b079bf