### PR TITLE
Handle invalid stored theme values

### DIFF
--- a/app/src/main/java/com/noahjutz/gymroutines/data/Preferences.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/data/Preferences.kt
@@ -32,7 +32,15 @@ enum class ColorTheme(
 ) {
     FollowSystem(R.string.app_theme_follow_system),
     White(R.string.app_theme_light),
-    Black(R.string.app_theme_dark)
+    Black(R.string.app_theme_dark);
+
+    companion object {
+        fun fromName(name: String?): ColorTheme {
+            if (name.isNullOrBlank()) return FollowSystem
+
+            return entries.firstOrNull { it.name == name } ?: FollowSystem
+        }
+    }
 }
 
 sealed class AppPrefs<T>(val key: Preferences.Key<T>, val defaultValue: T) {

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/main/MainScreenViewModel.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/main/MainScreenViewModel.kt
@@ -12,9 +12,7 @@ class MainScreenViewModel(
     preferences: DataStore<Preferences>
 ) : ViewModel() {
     val colorTheme = preferences.data.map { preferences ->
-        preferences[AppPrefs.AppTheme.key]?.let { key ->
-            ColorTheme.valueOf(key)
-        } ?: ColorTheme.FollowSystem
+        ColorTheme.fromName(preferences[AppPrefs.AppTheme.key])
     }
 
     val currentWorkoutId: Flow<Int> = preferences.data.map { preferences ->

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/settings/appearance/AppearanceSettingsViewModel.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/settings/appearance/AppearanceSettingsViewModel.kt
@@ -14,9 +14,7 @@ class AppearanceSettingsViewModel(
     private val preferences: DataStore<Preferences>
 ) : ViewModel() {
     val appTheme = preferences.data.map {
-        it[AppPrefs.AppTheme.key]?.let { colorThemeString ->
-            ColorTheme.valueOf(colorThemeString)
-        } ?: ColorTheme.FollowSystem
+        ColorTheme.fromName(it[AppPrefs.AppTheme.key])
     }
 
     fun setAppTheme(theme: ColorTheme) {


### PR DESCRIPTION
## Summary
- add a helper on `ColorTheme` to safely map persisted strings to enum values
- use the helper when reading theme preferences in `MainScreenViewModel` and `AppearanceSettingsViewModel` to fall back to the default when the stored value is invalid

## Testing
- ./gradlew assembleDebug --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e6d38da87c8324b40eb757b601b341