### PR TITLE
Integrate library exercises into core flows

### DIFF
--- a/app/src/main/java/com/noahjutz/gymroutines/data/Repository.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/data/Repository.kt
@@ -42,6 +42,10 @@ class ExerciseRepository(private val exerciseDao: ExerciseDao) {
     suspend fun getExercise(id: Int): Exercise? {
         return exerciseDao.getExercise(id)
     }
+
+    suspend fun getExerciseByTag(tag: String): Exercise? {
+        return exerciseDao.getExerciseByTag(tag)
+    }
 }
 
 class RoutineRepository(private val routineDao: RoutineDao) {

--- a/app/src/main/java/com/noahjutz/gymroutines/data/dao/ExerciseDao.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/data/dao/ExerciseDao.kt
@@ -41,4 +41,7 @@ interface ExerciseDao {
 
     @Query("SELECT * FROM exercise_table WHERE exerciseId == :id")
     fun getExerciseFlow(id: Int): Flow<Exercise?>
+
+    @Query("SELECT * FROM exercise_table WHERE tags = :tag LIMIT 1")
+    suspend fun getExerciseByTag(tag: String): Exercise?
 }

--- a/app/src/main/java/com/noahjutz/gymroutines/data/exerciselibrary/ExerciseLibraryMappers.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/data/exerciselibrary/ExerciseLibraryMappers.kt
@@ -22,7 +22,7 @@ private val distanceKeywords = setOf(
 fun ExerciseLibraryEntry.toExercise(): Exercise {
     val equipments = equipments.map { it.trim() }.filter { it.isNotEmpty() }
     val primaryMuscles = targetMuscles.map { it.trim() }.filter { it.isNotEmpty() }
-    val secondaryMuscles = secondaryMuscles.map { it.trim() }.filter { it.isNotEmpty() }
+    val secondaryMuscleList = secondaryMuscles.map { it.trim() }.filter { it.isNotEmpty() }
     val normalizedEquipments = equipments.map { it.lowercase(Locale.getDefault()) }
     val isBodyweight = normalizedEquipments.isEmpty() || normalizedEquipments.all { it in bodyweightKeywords }
     val likelyDistance = primaryMuscles.any { muscle ->
@@ -43,8 +43,8 @@ fun ExerciseLibraryEntry.toExercise(): Exercise {
             if (primaryMuscles.isNotEmpty()) {
                 add("Primary muscles: ${primaryMuscles.joinToString()}")
             }
-            if (secondaryMuscles.isNotEmpty()) {
-                add("Secondary muscles: ${secondaryMuscles.joinToString()}")
+            if (secondaryMuscleList.isNotEmpty()) {
+                add("Secondary muscles: ${secondaryMuscleList.joinToString()}")
             }
             force?.takeIf { it.isNotBlank() }?.let {
                 add("Force: ${it.replaceFirstChar { char -> char.titlecase(Locale.getDefault()) }}")
@@ -62,7 +62,7 @@ fun ExerciseLibraryEntry.toExercise(): Exercise {
     }
 
     return Exercise(
-        name = name.trim(),
+        name = displayName(),
         notes = notesSections.joinToString(separator = "\n\n").trim(),
         logReps = true,
         logWeight = !isBodyweight,
@@ -83,4 +83,20 @@ private fun formatSection(title: String, lines: List<String>): String {
         lines.filter { it.isNotBlank() }
             .forEach { line -> appendLine("\u2022 ${line.trim()}") }
     }.trimEnd()
+}
+
+fun ExerciseLibraryEntry.displayName(locale: Locale = Locale.getDefault()): String {
+    if (name.isBlank()) return name
+    return name.split(Regex("\\s+")).joinToString(" ") { token ->
+        token.split('-')
+            .joinToString("-") { part ->
+                if (part.any { it.isUpperCase() }) {
+                    part
+                } else {
+                    part.lowercase(locale).replaceFirstChar { char ->
+                        if (char.isLowerCase()) char.titlecase(locale) else char.toString()
+                    }
+                }
+            }
+    }
 }

--- a/app/src/main/java/com/noahjutz/gymroutines/data/exerciselibrary/ExerciseLibraryRepository.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/data/exerciselibrary/ExerciseLibraryRepository.kt
@@ -63,6 +63,10 @@ class ExerciseLibraryRepository(
         return library.entries.firstOrNull { it.id == id }
     }
 
+    suspend fun getExerciseByTag(tag: String): ExerciseLibraryEntry? {
+        return getExercise(tag.removePrefix("library:"))
+    }
+
     suspend fun relatedExercises(
         primaryMuscle: String?,
         equipment: String?,

--- a/app/src/main/java/com/noahjutz/gymroutines/di/Modules.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/di/Modules.kt
@@ -21,7 +21,6 @@ package com.noahjutz.gymroutines.di
 import androidx.room.Room
 import com.noahjutz.gymroutines.data.*
 import com.noahjutz.gymroutines.data.exerciselibrary.ExerciseLibraryRepository
-import com.noahjutz.gymroutines.ui.exercises.catalog.ExerciseCatalogViewModel
 import com.noahjutz.gymroutines.ui.exercises.editor.ExerciseEditorViewModel
 import com.noahjutz.gymroutines.ui.exercises.list.ExerciseListViewModel
 import com.noahjutz.gymroutines.ui.exercises.picker.ExercisePickerViewModel
@@ -96,18 +95,11 @@ val koinModule = module {
     }
 
     viewModel {
-        ExerciseCatalogViewModel(
-            repository = get(),
-            exerciseRepository = get()
-        )
+        ExerciseListViewModel(get(), get())
     }
 
     viewModel {
-        ExerciseListViewModel(get())
-    }
-
-    viewModel {
-        ExercisePickerViewModel(exerciseRepository = get())
+        ExercisePickerViewModel(exerciseRepository = get(), libraryRepository = get())
     }
 
     viewModel { params ->

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/NavGraph.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/NavGraph.kt
@@ -38,7 +38,6 @@ import com.google.accompanist.navigation.material.BottomSheetNavigator
 import com.google.accompanist.navigation.material.ExperimentalMaterialNavigationApi
 import com.google.accompanist.navigation.material.ModalBottomSheetLayout
 import com.google.accompanist.navigation.material.bottomSheet
-import com.noahjutz.gymroutines.ui.exercises.catalog.ExerciseCatalog
 import com.noahjutz.gymroutines.ui.exercises.editor.ExerciseEditor
 import com.noahjutz.gymroutines.ui.exercises.list.ExerciseList
 import com.noahjutz.gymroutines.ui.exercises.picker.ExercisePickerSheet
@@ -64,7 +63,6 @@ enum class Screen {
     routineEditor,
     exerciseList,
     exerciseEditor,
-    exerciseCatalog,
     exercisePicker,
     workoutInProgress,
     workoutViewer,
@@ -152,8 +150,7 @@ fun NavGraph(
             composable(Screen.exerciseList.name) {
                 ExerciseList(
                     navToExerciseEditor = { exerciseId -> navController.navigate("${Screen.exerciseEditor}?exerciseId=$exerciseId") },
-                    navToSettings = { navController.navigate(Screen.settings.name) },
-                    navToExerciseCatalog = { navController.navigate(Screen.exerciseCatalog.name) }
+                    navToSettings = { navController.navigate(Screen.settings.name) }
                 )
             }
             composable(
@@ -168,14 +165,6 @@ fun NavGraph(
                 ExerciseEditor(
                     exerciseId = backStackEntry.arguments!!.getInt("exerciseId"),
                     popBackStack = { navController.popBackStack() },
-                )
-            }
-            composable(Screen.exerciseCatalog.name) {
-                ExerciseCatalog(
-                    onBack = { navController.popBackStack() },
-                    onOpenMyExercises = {
-                        navController.popBackStack(Screen.exerciseList.name, inclusive = false)
-                    }
                 )
             }
             composable(

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/components/Chip.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/components/Chip.kt
@@ -1,0 +1,62 @@
+package com.noahjutz.gymroutines.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun Chip(
+    text: String,
+    modifier: Modifier = Modifier,
+    shape: Shape = MaterialTheme.shapes.small,
+) {
+    Surface(
+        modifier = modifier.clip(shape),
+        color = MaterialTheme.colors.onSurface.copy(alpha = 0.08f),
+        contentColor = MaterialTheme.colors.onSurface,
+        shape = shape
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.caption,
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp)
+        )
+    }
+}
+
+@Composable
+fun SelectableChip(
+    text: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    shape: Shape = MaterialTheme.shapes.small,
+) {
+    val background = if (selected) {
+        MaterialTheme.colors.primary.copy(alpha = 0.15f)
+    } else {
+        MaterialTheme.colors.onSurface.copy(alpha = 0.08f)
+    }
+    val contentColor = if (selected) MaterialTheme.colors.primary else MaterialTheme.colors.onSurface
+    Surface(
+        modifier = modifier
+            .clip(shape)
+            .clickable(onClick = onClick),
+        color = background,
+        contentColor = contentColor,
+        shape = shape
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.caption,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp)
+        )
+    }
+}

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/exercises/detail/ExerciseDetailDialog.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/exercises/detail/ExerciseDetailDialog.kt
@@ -1,0 +1,286 @@
+package com.noahjutz.gymroutines.ui.exercises.detail
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.Alignment
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.noahjutz.gymroutines.R
+import com.noahjutz.gymroutines.data.domain.Exercise
+import com.noahjutz.gymroutines.data.exerciselibrary.ExerciseLibraryEntry
+import com.noahjutz.gymroutines.data.exerciselibrary.displayName
+import com.noahjutz.gymroutines.ui.components.Chip
+import com.noahjutz.gymroutines.ui.exercises.list.formatTag
+import com.noahjutz.gymroutines.ui.exercises.list.ExerciseListItem
+import com.noahjutz.gymroutines.data.exerciselibrary.ExerciseLibraryRepository
+import java.util.Locale
+
+sealed class ExerciseDetailData {
+    data class Library(val entry: ExerciseLibraryEntry, val exercise: Exercise? = null) : ExerciseDetailData()
+    data class Custom(val exercise: Exercise) : ExerciseDetailData()
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun ExerciseDetailDialog(
+    data: ExerciseDetailData,
+    onDismiss: () -> Unit,
+    onEdit: ((Int) -> Unit)? = null,
+    onSave: (() -> Unit)? = null,
+) {
+    val locale = remember { Locale.getDefault() }
+    Dialog(onDismissRequest = onDismiss) {
+        Surface(shape = MaterialTheme.shapes.large, color = MaterialTheme.colors.surface) {
+            Column(modifier = Modifier.padding(20.dp)) {
+                when (data) {
+                    is ExerciseDetailData.Library -> LibraryExerciseDetail(
+                        data = data,
+                        locale = locale,
+                        onEdit = onEdit,
+                        onSave = onSave
+                    )
+                    is ExerciseDetailData.Custom -> CustomExerciseDetail(
+                        exercise = data.exercise,
+                        onEdit = onEdit
+                    )
+                }
+                Spacer(modifier = Modifier.height(12.dp))
+                TextButton(
+                    modifier = Modifier.align(Alignment.End),
+                    onClick = onDismiss
+                ) {
+                    Text(stringResource(R.string.btn_close))
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun LibraryExerciseDetail(
+    data: ExerciseDetailData.Library,
+    locale: Locale,
+    onEdit: ((Int) -> Unit)?,
+    onSave: (() -> Unit)?
+) {
+    val entry = data.entry
+    val exercise = data.exercise
+    val displayName = entry.displayName(locale)
+    Column {
+        Text(
+            text = displayName,
+            style = MaterialTheme.typography.h6,
+            fontWeight = FontWeight.Bold
+        )
+        val heroPath = entry.heroAsset?.let { "file:///android_asset/exercise_index/$it" }
+        heroPath?.let { path ->
+            Spacer(modifier = Modifier.height(12.dp))
+            AsyncImage(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(220.dp)
+                    .padding(bottom = 4.dp),
+                model = ImageRequest.Builder(LocalContext.current)
+                    .data(path)
+                    .crossfade(true)
+                    .build(),
+                contentDescription = null,
+                contentScale = ContentScale.Crop
+            )
+        }
+        FlowRow(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 8.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            entry.bodyParts.forEach { part ->
+                Chip(
+                    text = part.formatTag(locale),
+                    modifier = Modifier.padding(bottom = 8.dp)
+                )
+            }
+            entry.equipments.forEach { equipment ->
+                Chip(
+                    text = equipment.formatTag(locale),
+                    modifier = Modifier.padding(bottom = 8.dp)
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(12.dp))
+        if (entry.instructions.isNotEmpty()) {
+            SectionHeader(stringResource(R.string.label_instructions_header))
+            Spacer(modifier = Modifier.height(4.dp))
+            entry.instructions.forEachIndexed { index, instruction ->
+                Text("${index + 1}. ${instruction.trim()}", style = MaterialTheme.typography.body2)
+                Spacer(modifier = Modifier.height(4.dp))
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+        if (entry.tips.isNotEmpty()) {
+            SectionHeader(stringResource(R.string.label_tips_header))
+            Spacer(modifier = Modifier.height(4.dp))
+            entry.tips.forEach { tip ->
+                Text("• ${tip.trim()}", style = MaterialTheme.typography.body2)
+                Spacer(modifier = Modifier.height(2.dp))
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+
+        val metadata = listOfNotNull(
+            entry.targetMuscles.takeIf { it.isNotEmpty() }?.let {
+                stringResource(
+                    R.string.label_primary_muscles,
+                    it.joinToString { muscle -> muscle.formatTag(locale) }
+                )
+            },
+            entry.secondaryMuscles.takeIf { it.isNotEmpty() }?.let {
+                stringResource(
+                    R.string.label_secondary_muscles,
+                    it.joinToString { muscle -> muscle.formatTag(locale) }
+                )
+            },
+            entry.mechanic?.takeIf { it.isNotBlank() }?.let {
+                stringResource(R.string.label_mechanic, it.formatTag(locale))
+            },
+            entry.force?.takeIf { it.isNotBlank() }?.let {
+                stringResource(R.string.label_force, it.formatTag(locale))
+            },
+            entry.difficulty?.takeIf { it.isNotBlank() }?.let {
+                stringResource(R.string.label_difficulty, it.formatTag(locale))
+            }
+        )
+        if (metadata.isNotEmpty()) {
+            Divider(modifier = Modifier.padding(vertical = 12.dp))
+            metadata.forEach { line ->
+                Text(line, style = MaterialTheme.typography.body2)
+                Spacer(modifier = Modifier.height(4.dp))
+            }
+        }
+
+        Spacer(modifier = Modifier.height(12.dp))
+        androidx.compose.foundation.layout.Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.End
+        ) {
+            if (onSave != null && exercise == null) {
+                TextButton(onClick = onSave) {
+                    Text(stringResource(R.string.btn_add_to_my_exercises))
+                }
+            }
+            if (onEdit != null) {
+                exercise?.let {
+                    TextButton(onClick = { onEdit(it.exerciseId) }) {
+                        Text(stringResource(R.string.btn_edit_exercise))
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CustomExerciseDetail(
+    exercise: Exercise,
+    onEdit: ((Int) -> Unit)?
+) {
+    Column {
+        Text(
+            text = exercise.name.ifBlank { stringResource(R.string.unnamed_exercise) },
+            style = MaterialTheme.typography.h6,
+            fontWeight = FontWeight.Bold
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        if (exercise.notes.isNotBlank()) {
+            SectionHeader(stringResource(R.string.label_exercise_notes))
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = exercise.notes,
+                style = MaterialTheme.typography.body2
+            )
+        }
+        Spacer(modifier = Modifier.height(12.dp))
+        SectionHeader(stringResource(R.string.label_tracking_options))
+        Spacer(modifier = Modifier.height(4.dp))
+        val tracking = buildList {
+            if (exercise.logReps) add(stringResource(R.string.checkbox_log_reps))
+            if (exercise.logWeight) add(stringResource(R.string.checkbox_log_weight))
+            if (exercise.logTime) add(stringResource(R.string.checkbox_log_time))
+            if (exercise.logDistance) add(stringResource(R.string.checkbox_log_distance))
+        }
+        if (tracking.isNotEmpty()) {
+            tracking.forEach { option ->
+                Text("• $option", style = MaterialTheme.typography.body2)
+            }
+        } else {
+            Text(
+                text = stringResource(R.string.hint_exercise_tracking_none),
+                style = MaterialTheme.typography.body2,
+                color = MaterialTheme.colors.onSurface.copy(alpha = 0.7f)
+            )
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+        onEdit?.let { edit ->
+            TextButton(
+                modifier = Modifier.align(Alignment.End),
+                onClick = { edit(exercise.exerciseId) }
+            ) {
+                Text(stringResource(R.string.btn_edit_exercise))
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionHeader(title: String) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.subtitle2.copy(fontWeight = FontWeight.SemiBold)
+    )
+}
+
+fun ExerciseListItem.toDetailData(): ExerciseDetailData? {
+    return when {
+        entry != null -> ExerciseDetailData.Library(entry, exercise)
+        exercise != null -> ExerciseDetailData.Custom(exercise)
+        else -> null
+    }
+}
+
+suspend fun resolveExerciseDetail(
+    exercise: Exercise,
+    libraryRepository: ExerciseLibraryRepository
+): ExerciseDetailData {
+    return if (exercise.tags.startsWith("library:")) {
+        val entry = libraryRepository.getExerciseByTag(exercise.tags)
+        if (entry != null) {
+            ExerciseDetailData.Library(entry, exercise)
+        } else {
+            ExerciseDetailData.Custom(exercise)
+        }
+    } else {
+        ExerciseDetailData.Custom(exercise)
+    }
+}

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/exercises/list/ExerciseListItemMappers.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/exercises/list/ExerciseListItemMappers.kt
@@ -1,0 +1,114 @@
+package com.noahjutz.gymroutines.ui.exercises.list
+
+import com.noahjutz.gymroutines.data.domain.Exercise
+import com.noahjutz.gymroutines.data.exerciselibrary.ExerciseLibraryEntry
+import com.noahjutz.gymroutines.data.exerciselibrary.displayName
+import java.util.Locale
+
+internal const val CUSTOM_FILTER_TAG = "Custom"
+internal const val LIBRARY_TAG_PREFIX = "library:"
+
+internal fun Exercise.toCustomListItem(locale: Locale): ExerciseListItem {
+    val normalizedName = name.lowercase(locale)
+    val searchable = buildList {
+        add(normalizedName)
+        if (notes.isNotBlank()) {
+            add(notes.lowercase(locale))
+        }
+    }
+    return ExerciseListItem(
+        key = exerciseId.toString(),
+        title = name,
+        subtitle = null,
+        chips = listOf(CUSTOM_FILTER_TAG),
+        searchTexts = searchable,
+        filterTags = setOf(CUSTOM_FILTER_TAG),
+        sortKey = normalizedName,
+        exerciseId = exerciseId,
+        exercise = this,
+        entry = null
+    )
+}
+
+internal fun Exercise.toLibraryListItem(entry: ExerciseLibraryEntry, locale: Locale): ExerciseListItem {
+    return entry.toLibraryListItem(locale, importedExercise = this)
+}
+
+internal fun ExerciseLibraryEntry.toLibraryListItem(
+    locale: Locale,
+    importedExercise: Exercise? = null
+): ExerciseListItem {
+    val displayName = displayName(locale)
+    val subtitle = buildList {
+        targetMuscles.takeIf { it.isNotEmpty() }
+            ?.joinToString { muscle -> muscle.formatTag(locale) }
+            ?.takeIf { it.isNotBlank() }
+            ?.let(::add)
+        equipments.takeIf { it.isNotEmpty() }
+            ?.joinToString { equipment -> equipment.formatTag(locale) }
+            ?.takeIf { it.isNotBlank() }
+            ?.let(::add)
+    }.joinToString(" • ").ifBlank { null }
+
+    val chips = buildList {
+        bodyParts.mapTo(this) { it.formatTag(locale) }
+        equipments.mapTo(this) { it.formatTag(locale) }
+    }
+
+    val searchTexts = buildSet {
+        add(displayName.lowercase(locale))
+        add(name.lowercase(locale))
+        alias.mapTo(this) { it.lowercase(locale) }
+        searchTerms.mapTo(this) { it.lowercase(locale) }
+    }
+
+    val filterTags = bodyParts.mapTo(mutableSetOf()) { it.formatTag(locale) }
+    equipments.mapTo(filterTags) { it.formatTag(locale) }
+
+    return ExerciseListItem(
+        key = importedExercise?.exerciseId?.toString() ?: "${LIBRARY_TAG_PREFIX}$id",
+        title = displayName,
+        subtitle = subtitle,
+        chips = chips,
+        searchTexts = searchTexts.toList(),
+        filterTags = filterTags,
+        sortKey = displayName.lowercase(locale),
+        exerciseId = importedExercise?.exerciseId,
+        exercise = importedExercise,
+        entry = this
+    )
+}
+
+internal fun ExerciseListItem.matchesQuery(query: String): Boolean {
+    if (query.isBlank()) return true
+    return searchTexts.any { it.contains(query) }
+}
+
+internal fun ExerciseListItem.matchesFilters(selected: Set<String>): Boolean {
+    if (selected.isEmpty()) return true
+    return selected.any { it in filterTags }
+}
+
+internal fun ExerciseListItem.matchesQuery(query: String, filters: Set<String>): Boolean {
+    return matchesQuery(query) && matchesFilters(filters)
+}
+
+internal fun ExerciseListItem.isSameLibraryEntry(libraryId: String): Boolean {
+    return entry?.id == libraryId
+}
+
+internal fun String.formatTag(locale: Locale): String {
+    if (isBlank()) return this
+    return split(Regex("\\s+")).joinToString(" ") { token ->
+        token.split('-')
+            .joinToString("-") { part ->
+                if (part.any(Char::isUpperCase)) {
+                    part
+                } else {
+                    part.lowercase(locale).replaceFirstChar { char ->
+                        if (char.isLowerCase()) char.titlecase(locale) else char.toString()
+                    }
+                }
+            }
+    }
+}

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/exercises/list/ExerciseListViewModel.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/exercises/list/ExerciseListViewModel.kt
@@ -1,69 +1,156 @@
-/*
- * Splitfit
- * Copyright (C) 2020  Noah Jutz
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package com.noahjutz.gymroutines.ui.exercises.list
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.noahjutz.gymroutines.data.ExerciseRepository
 import com.noahjutz.gymroutines.data.domain.Exercise
+import com.noahjutz.gymroutines.data.exerciselibrary.ExerciseLibraryEntry
+import com.noahjutz.gymroutines.data.exerciselibrary.ExerciseLibraryRepository
+import com.noahjutz.gymroutines.data.exerciselibrary.displayName
+import com.noahjutz.gymroutines.data.exerciselibrary.libraryTag
+import com.noahjutz.gymroutines.data.exerciselibrary.toExercise
 import java.util.Locale
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class ExerciseListViewModel(
     private val repository: ExerciseRepository,
+    private val libraryRepository: ExerciseLibraryRepository,
 ) : ViewModel() {
-    private val _nameFilter = MutableStateFlow("")
-    val nameFilter = _nameFilter.asStateFlow()
+    private val query = MutableStateFlow("")
+    private val selectedFilters = MutableStateFlow(setOf<String>())
+    private val locale: Locale = Locale.getDefault()
 
-    fun setNameFilter(filter: String) {
-        _nameFilter.value = filter
+    init {
+        viewModelScope.launch { libraryRepository.ensureLoaded() }
     }
 
-    val exercises = repository.exercises
-        .combine(_nameFilter) { exercises, nameFilter ->
-            val locale = Locale.getDefault()
-            val normalizedFilter = nameFilter.trim().lowercase(locale)
-            val visibleExercises = exercises.filterNot(Exercise::hidden)
+    fun setNameFilter(filter: String) {
+        query.value = filter
+    }
 
-            if (normalizedFilter.isEmpty()) {
-                visibleExercises
-            } else {
-                visibleExercises.filter { exercise ->
-                    exercise.name.lowercase(locale).contains(normalizedFilter)
+    fun toggleFilter(filter: String) {
+        selectedFilters.update { current ->
+            if (filter in current) current - filter else current + filter
+        }
+    }
+
+    fun clearFilters() {
+        selectedFilters.value = emptySet()
+    }
+
+    val uiState: StateFlow<ExerciseListUiState> = combine(
+        repository.exercises,
+        libraryRepository.observe(),
+        query,
+        selectedFilters
+    ) { exercises, library, queryValue, filters ->
+        val normalizedQuery = queryValue.trim().lowercase(locale)
+        val libraryEntries = library?.entries.orEmpty()
+        val libraryById = libraryEntries.associateBy { it.id }
+
+        val visibleExercises = exercises.filterNot(Exercise::hidden)
+        val hiddenLibraryIds = exercises.filter { it.hidden && it.tags.startsWith(LIBRARY_TAG_PREFIX) }
+            .mapNotNull { it.tags.removePrefix(LIBRARY_TAG_PREFIX).takeIf(String::isNotBlank) }
+            .toSet()
+
+        val items = buildList<ExerciseListItem> {
+            visibleExercises.forEach { exercise ->
+                if (exercise.tags.startsWith(LIBRARY_TAG_PREFIX)) {
+                    val id = exercise.tags.removePrefix(LIBRARY_TAG_PREFIX)
+                    val entry = libraryById[id]
+                    if (entry != null) {
+                        add(exercise.toLibraryListItem(entry, locale))
+                    }
+                } else {
+                    add(exercise.toCustomListItem(locale))
+                }
+            }
+
+            libraryEntries.forEach { entry ->
+                if (entry.id !in hiddenLibraryIds && this.none { it.isSameLibraryEntry(entry.id) }) {
+                    add(entry.toLibraryListItem(locale))
                 }
             }
         }
+
+        val filteredItems = items
+            .filter { item -> item.matchesQuery(normalizedQuery, filters) }
+            .sortedBy { it.sortKey }
+
+        val availableFilters = buildList {
+            add(CUSTOM_FILTER_TAG)
+            library?.metadata?.bodyParts.orEmpty()
+                .map { it.formatTag(locale) }
+                .forEach { tag -> if (tag !in this) add(tag) }
+            library?.metadata?.equipments.orEmpty()
+                .map { it.formatTag(locale) }
+                .forEach { tag -> if (tag !in this) add(tag) }
+        }
+
+        ExerciseListUiState(
+            isLoading = library == null,
+            query = queryValue,
+            selectedFilters = filters,
+            availableFilters = availableFilters,
+            items = filteredItems
+        )
+    }
         .flowOn(Dispatchers.Default)
-        .distinctUntilChanged()
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = ExerciseListUiState(isLoading = true)
+        )
 
     fun delete(exercise: Exercise) {
         viewModelScope.launch {
             repository.update(exercise.copy(hidden = true))
         }
     }
+
+    fun ensureExercise(entry: ExerciseLibraryEntry, onResult: (Int) -> Unit = {}) {
+        viewModelScope.launch {
+            val existing = repository.getExerciseByTag(entry.libraryTag)
+            val desiredName = entry.displayName(locale)
+            val exerciseId = if (existing != null) {
+                if (existing.name.equals(entry.name.trim(), ignoreCase = true) && existing.name != desiredName) {
+                    repository.update(existing.copy(name = desiredName))
+                }
+                existing.exerciseId
+            } else {
+                repository.insert(entry.toExercise()).toInt()
+            }
+            onResult(exerciseId)
+        }
+    }
+
 }
+
+data class ExerciseListUiState(
+    val isLoading: Boolean = false,
+    val query: String = "",
+    val selectedFilters: Set<String> = emptySet(),
+    val availableFilters: List<String> = emptyList(),
+    val items: List<ExerciseListItem> = emptyList()
+)
+
+data class ExerciseListItem(
+    val key: String,
+    val title: String,
+    val subtitle: String?,
+    val chips: List<String>,
+    val searchTexts: List<String>,
+    val filterTags: Set<String>,
+    val sortKey: String,
+    val exerciseId: Int?,
+    val exercise: Exercise?,
+    val entry: ExerciseLibraryEntry?
+)

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/routines/editor/RoutineEditor.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/routines/editor/RoutineEditor.kt
@@ -31,7 +31,9 @@ import androidx.compose.material.MaterialTheme.colors
 import androidx.compose.material.MaterialTheme.typography
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.runtime.*
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.SolidColor
@@ -44,6 +46,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.noahjutz.gymroutines.R
+import com.noahjutz.gymroutines.data.domain.Exercise
 import com.noahjutz.gymroutines.data.domain.Routine
 import com.noahjutz.gymroutines.data.domain.RoutineSetGroupWithSets
 import com.noahjutz.gymroutines.ui.components.AutoSelectTextField
@@ -54,11 +57,16 @@ import com.noahjutz.gymroutines.ui.components.SwipeToDeleteBackground
 import com.noahjutz.gymroutines.ui.components.TopBar
 import com.noahjutz.gymroutines.ui.components.WarmupIndicatorWidth
 import com.noahjutz.gymroutines.ui.components.durationVisualTransformation
+import com.noahjutz.gymroutines.data.exerciselibrary.ExerciseLibraryRepository
+import com.noahjutz.gymroutines.ui.exercises.detail.ExerciseDetailData
+import com.noahjutz.gymroutines.ui.exercises.detail.ExerciseDetailDialog
+import com.noahjutz.gymroutines.ui.exercises.detail.resolveExerciseDetail
 import com.noahjutz.gymroutines.util.RegexPatterns
 import com.noahjutz.gymroutines.util.formatRestDuration
 import com.noahjutz.gymroutines.util.formatSimple
 import com.noahjutz.gymroutines.util.toStringOrBlank
 import org.koin.androidx.compose.getViewModel
+import org.koin.androidx.compose.get
 import org.koin.core.parameter.parametersOf
 import kotlinx.coroutines.launch
 
@@ -212,6 +220,7 @@ private data class ExerciseNotesDialogState(
     val notes: String,
 )
 
+
 @OptIn(ExperimentalMaterialApi::class, ExperimentalFoundationApi::class)
 @Composable
 private fun RoutineEditorContent(
@@ -252,6 +261,13 @@ private fun RoutineEditorContent(
                 restTimerEditorGroup = null
             }
         )
+    }
+
+    val libraryRepository: ExerciseLibraryRepository = get()
+    val coroutineScope = rememberCoroutineScope()
+    var detailDialog by remember { mutableStateOf<ExerciseDetailData?>(null) }
+    detailDialog?.let { data ->
+        ExerciseDetailDialog(data = data, onDismiss = { detailDialog = null })
     }
 
     LazyColumn(
@@ -352,6 +368,17 @@ private fun RoutineEditorContent(
                                     .padding(horizontal = 16.dp, vertical = 10.dp)
                                     .weight(1f)
                             )
+
+                            IconButton(onClick = {
+                                coroutineScope.launch {
+                                    detailDialog = resolveExerciseDetail(exercise, libraryRepository)
+                                }
+                            }) {
+                                Icon(
+                                    Icons.Default.Info,
+                                    contentDescription = stringResource(R.string.btn_view_details)
+                                )
+                            }
 
                             Box {
                                 var expanded by remember { mutableStateOf(false) }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,6 +31,7 @@
     <string name="checkbox_log_weight">Log Weight</string>
     <string name="checkbox_log_time">Log Time</string>
     <string name="checkbox_log_distance">Log Distance</string>
+    <string name="checkbox_update_routine">Update routine</string>
     <string name="screen_routine_list">Routines</string>
     <string name="screen_exercise_list">Exercises</string>
     <string name="screen_exercise_catalog">Exercise library</string>
@@ -73,11 +74,15 @@
     <string name="btn_save">Save</string>
     <string name="label_exercise_name">Exercise name</string>
     <string name="label_exercise_notes">Notes</string>
+    <string name="label_tracking_options">Tracking</string>
     <string name="btn_add_notes">Add notes</string>
     <string name="btn_edit_notes">Edit notes</string>
+    <string name="btn_edit_exercise">Edit exercise</string>
+    <string name="btn_view_details">View details</string>
     <string name="dialog_title_edit_notes">Edit notes for %1$s</string>
     <string name="unnamed_exercise">Unnamed exercise</string>
     <string name="btn_more">More</string>
+    <string name="btn_clear_filters">Clear filters</string>
     <string name="btn_delete">Delete</string>
     <string name="dialog_item_set">this set</string>
     <string name="btn_select_option">Select</string>
@@ -198,6 +203,9 @@
     <string name="rest_timer_indicator_working">Set rest</string>
     <string name="rest_timer_minus_30">-30s</string>
     <string name="rest_timer_plus_30">+30s</string>
+    <string name="hint_exercise_list_empty_title">No exercises yet</string>
+    <string name="hint_exercise_list_empty_body">Browse the tags or use the search to find a movement. You can always create your own exercise, too!</string>
+    <string name="hint_exercise_tracking_none">No metrics are tracked for this exercise.</string>
     <string name="rest_timer_plus_minute">+1:00</string>
     <string name="rest_timer_notification_running_title">Rest timer</string>
     <string name="rest_timer_notification_running_body">%1$s • %2$s remaining</string>


### PR DESCRIPTION
## Summary
- merge custom and library exercises into a single exercise list with chip filters, quick import actions, and a richer detail dialog
- surface the shared detail experience from the picker, routine editor, and active workout screens while formatting library names and tags for display

## Testing
- ./gradlew assembleDebug --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e776dd56188324a94af86920eb8efe