### PR TITLE
Enhance exercise detail view and filtering experience

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -143,6 +143,7 @@ dependencies {
     implementation("com.google.accompanist:accompanist-navigation-animation:0.30.1")
     implementation("com.google.accompanist:accompanist-placeholder-material:0.30.1")
     implementation("io.coil-kt:coil-compose:2.4.0")
+    implementation("io.coil-kt:coil-gif:2.4.0")
 
     androidTestImplementation("androidx.test:core:1.5.0")
     androidTestImplementation("androidx.test:core-ktx:1.5.0")

--- a/app/schemas/com.noahjutz.gymroutines.data.AppDatabase/47.json
+++ b/app/schemas/com.noahjutz.gymroutines.data.AppDatabase/47.json
@@ -1,0 +1,467 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 47,
+    "identityHash": "85df75f34d3591e4f69040453ee2e983",
+    "entities": [
+      {
+        "tableName": "exercise_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `notes` TEXT NOT NULL DEFAULT '', `libraryNotes` TEXT NOT NULL DEFAULT '', `logReps` INTEGER NOT NULL, `logWeight` INTEGER NOT NULL, `logTime` INTEGER NOT NULL, `logDistance` INTEGER NOT NULL, `hidden` INTEGER NOT NULL, `tags` TEXT NOT NULL DEFAULT 'custom', `exerciseId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "libraryNotes",
+            "columnName": "libraryNotes",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "logReps",
+            "columnName": "logReps",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "logWeight",
+            "columnName": "logWeight",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "logTime",
+            "columnName": "logTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "logDistance",
+            "columnName": "logDistance",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hidden",
+            "columnName": "hidden",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'custom'"
+          },
+          {
+            "fieldPath": "exerciseId",
+            "columnName": "exerciseId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "exerciseId"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "routine_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `hidden` INTEGER NOT NULL, `routineId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hidden",
+            "columnName": "hidden",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "routineId",
+            "columnName": "routineId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "routineId"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "workout_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`routineId` INTEGER NOT NULL, `startTime` INTEGER NOT NULL, `endTime` INTEGER NOT NULL, `workoutId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "routineId",
+            "columnName": "routineId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "startTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endTime",
+            "columnName": "endTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workoutId",
+            "columnName": "workoutId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "workoutId"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "routine_set_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`groupId` INTEGER NOT NULL, `reps` INTEGER, `weight` REAL, `time` INTEGER, `distance` REAL, `isWarmup` INTEGER NOT NULL, `routineSetId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`groupId`) REFERENCES `routine_set_group_table`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reps",
+            "columnName": "reps",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "weight",
+            "columnName": "weight",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "time",
+            "columnName": "time",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "distance",
+            "columnName": "distance",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isWarmup",
+            "columnName": "isWarmup",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "routineSetId",
+            "columnName": "routineSetId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "routineSetId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_routine_set_table_groupId",
+            "unique": false,
+            "columnNames": [
+              "groupId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_routine_set_table_groupId` ON `${TABLE_NAME}` (`groupId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "routine_set_group_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "groupId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "routine_set_group_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`routineId` INTEGER NOT NULL, `exerciseId` INTEGER NOT NULL, `position` INTEGER NOT NULL, `restTimerWarmupSeconds` INTEGER NOT NULL, `restTimerWorkingSeconds` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`routineId`) REFERENCES `routine_table`(`routineId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "routineId",
+            "columnName": "routineId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exerciseId",
+            "columnName": "exerciseId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "restTimerWarmupSeconds",
+            "columnName": "restTimerWarmupSeconds",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "restTimerWorkingSeconds",
+            "columnName": "restTimerWorkingSeconds",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_routine_set_group_table_routineId",
+            "unique": false,
+            "columnNames": [
+              "routineId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_routine_set_group_table_routineId` ON `${TABLE_NAME}` (`routineId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "routine_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "routineId"
+            ],
+            "referencedColumns": [
+              "routineId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "workout_set_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`groupId` INTEGER NOT NULL, `reps` INTEGER, `weight` REAL, `time` INTEGER, `distance` REAL, `complete` INTEGER NOT NULL, `isWarmup` INTEGER NOT NULL, `workoutSetId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`groupId`) REFERENCES `workout_set_group_table`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reps",
+            "columnName": "reps",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "weight",
+            "columnName": "weight",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "time",
+            "columnName": "time",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "distance",
+            "columnName": "distance",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "complete",
+            "columnName": "complete",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isWarmup",
+            "columnName": "isWarmup",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workoutSetId",
+            "columnName": "workoutSetId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "workoutSetId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_workout_set_table_groupId",
+            "unique": false,
+            "columnNames": [
+              "groupId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_workout_set_table_groupId` ON `${TABLE_NAME}` (`groupId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "workout_set_group_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "groupId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "workout_set_group_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`workoutId` INTEGER NOT NULL, `exerciseId` INTEGER NOT NULL, `position` INTEGER NOT NULL, `restTimerWarmupSeconds` INTEGER NOT NULL, `restTimerWorkingSeconds` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`workoutId`) REFERENCES `workout_table`(`workoutId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "workoutId",
+            "columnName": "workoutId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exerciseId",
+            "columnName": "exerciseId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "restTimerWarmupSeconds",
+            "columnName": "restTimerWarmupSeconds",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "restTimerWorkingSeconds",
+            "columnName": "restTimerWorkingSeconds",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_workout_set_group_table_workoutId",
+            "unique": false,
+            "columnNames": [
+              "workoutId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_workout_set_group_table_workoutId` ON `${TABLE_NAME}` (`workoutId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "workout_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "workoutId"
+            ],
+            "referencedColumns": [
+              "workoutId"
+            ]
+          }
+        ]
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '85df75f34d3591e4f69040453ee2e983')"
+    ]
+  }
+}

--- a/app/src/main/java/com/noahjutz/gymroutines/data/AppDatabase.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/data/AppDatabase.kt
@@ -40,7 +40,7 @@ import kotlinx.serialization.json.*
         WorkoutSet::class,
         WorkoutSetGroup::class,
     ],
-    version = 46,
+    version = 47,
     autoMigrations = [AutoMigration(from = 35, to = 36)],
     exportSchema = true
 )
@@ -640,6 +640,17 @@ val MIGRATION_45_46 = object : Migration(45, 46) {
     override fun migrate(db: SupportSQLiteDatabase) {
         db.execSQL(
             "ALTER TABLE exercise_table ADD COLUMN tags TEXT NOT NULL DEFAULT 'custom'"
+        )
+    }
+}
+
+val MIGRATION_46_47 = object : Migration(46, 47) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            "ALTER TABLE exercise_table ADD COLUMN libraryNotes TEXT NOT NULL DEFAULT ''"
+        )
+        db.execSQL(
+            "UPDATE exercise_table SET libraryNotes = notes WHERE tags LIKE 'library:%'"
         )
     }
 }

--- a/app/src/main/java/com/noahjutz/gymroutines/data/domain/Exercise.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/data/domain/Exercise.kt
@@ -27,6 +27,8 @@ data class Exercise(
     var name: String = "",
     @ColumnInfo(defaultValue = "")
     var notes: String = "",
+    @ColumnInfo(defaultValue = "")
+    var libraryNotes: String = "",
     var logReps: Boolean = true,
     var logWeight: Boolean = false,
     var logTime: Boolean = false,

--- a/app/src/main/java/com/noahjutz/gymroutines/data/exerciselibrary/ExerciseLibraryMappers.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/data/exerciselibrary/ExerciseLibraryMappers.kt
@@ -61,9 +61,12 @@ fun ExerciseLibraryEntry.toExercise(): Exercise {
         }
     }
 
+    val libraryNotes = notesSections.joinToString(separator = "\n\n").trim()
+
     return Exercise(
         name = displayName(),
-        notes = notesSections.joinToString(separator = "\n\n").trim(),
+        notes = "",
+        libraryNotes = libraryNotes,
         logReps = true,
         logWeight = !isBodyweight,
         logTime = false,

--- a/app/src/main/java/com/noahjutz/gymroutines/di/Modules.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/di/Modules.kt
@@ -54,6 +54,7 @@ val koinModule = module {
                 MIGRATION_43_44,
                 MIGRATION_44_45,
                 MIGRATION_45_46,
+                MIGRATION_46_47,
             )
             .build()
     }

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/exercises/components/ExerciseFilterPanel.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/exercises/components/ExerciseFilterPanel.kt
@@ -1,0 +1,88 @@
+package com.noahjutz.gymroutines.ui.exercises.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.noahjutz.gymroutines.R
+import com.noahjutz.gymroutines.ui.components.SelectableChip
+
+@OptIn(ExperimentalLayoutApi::class, ExperimentalAnimationApi::class)
+@Composable
+fun ExerciseFilterPanel(
+    availableFilters: List<String>,
+    selectedFilters: Set<String>,
+    onToggle: (String) -> Unit,
+    onClear: () -> Unit,
+    modifier: Modifier = Modifier,
+    initiallyExpanded: Boolean = false,
+) {
+    if (availableFilters.isEmpty()) return
+
+    var expanded by rememberSaveable(availableFilters) { mutableStateOf(initiallyExpanded) }
+
+    Column(modifier = modifier) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 4.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.label_filter_options),
+                style = MaterialTheme.typography.subtitle2.copy(fontWeight = FontWeight.SemiBold),
+                modifier = Modifier.padding(vertical = 8.dp)
+            )
+            Spacer(modifier = Modifier.weight(1f))
+            if (selectedFilters.isNotEmpty()) {
+                TextButton(onClick = onClear) {
+                    Text(stringResource(R.string.btn_clear_filters))
+                }
+            }
+            TextButton(onClick = { expanded = !expanded }) {
+                val label = if (expanded) {
+                    stringResource(R.string.filters_hide)
+                } else {
+                    stringResource(R.string.filters_show)
+                }
+                Text(label)
+            }
+        }
+
+        AnimatedVisibility(visible = expanded) {
+            FlowRow(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                availableFilters.forEach { filter ->
+                    val selected = selectedFilters.contains(filter)
+                    SelectableChip(
+                        text = filter,
+                        selected = selected,
+                        onClick = { onToggle(filter) },
+                        modifier = Modifier.padding(bottom = 8.dp)
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/exercises/editor/ExerciseEditorViewModel.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/exercises/editor/ExerciseEditorViewModel.kt
@@ -65,6 +65,7 @@ class ExerciseEditorViewModel(
             _originalExercise.value = repository.getExercise(exerciseId)
 
             _originalExercise.value?.let {
+                _currentExercise.value = it
                 _name.value = it.name
                 _notes.value = it.notes
                 _logReps.value = it.logReps
@@ -140,7 +141,8 @@ class ExerciseEditorViewModel(
 
     fun save(onComplete: () -> Unit) {
         viewModelScope.launch {
-            val exercise = Exercise(
+            val base = _currentExercise.value ?: Exercise(exerciseId = exerciseId)
+            val exercise = base.copy(
                 name = name.value,
                 notes = notes.value,
                 logReps = logReps.value,

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/exercises/list/ExerciseList.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/exercises/list/ExerciseList.kt
@@ -47,11 +47,11 @@ import androidx.compose.ui.unit.dp
 import com.noahjutz.gymroutines.R
 import com.noahjutz.gymroutines.ui.components.Chip
 import com.noahjutz.gymroutines.ui.components.SearchBar
-import com.noahjutz.gymroutines.ui.components.SelectableChip
 import com.noahjutz.gymroutines.ui.components.SwipeToDeleteBackground
 import com.noahjutz.gymroutines.ui.components.TopBar
 import com.noahjutz.gymroutines.ui.exercises.detail.ExerciseDetailDialog
 import com.noahjutz.gymroutines.ui.exercises.detail.toDetailData
+import com.noahjutz.gymroutines.ui.exercises.components.ExerciseFilterPanel
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.getViewModel
 
@@ -135,35 +135,14 @@ fun ExerciseList(
                 onValueChange = viewModel::setNameFilter
             )
 
-            if (uiState.availableFilters.isNotEmpty()) {
-                FlowRow(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    uiState.availableFilters.forEach { filter ->
-                        val selected = filter in uiState.selectedFilters
-                        SelectableChip(
-                            text = filter,
-                            selected = selected,
-                            onClick = { viewModel.toggleFilter(filter) },
-                            modifier = Modifier.padding(bottom = 8.dp)
-                        )
-                    }
-                }
-
-                if (uiState.selectedFilters.isNotEmpty()) {
-                    TextButton(
-                        modifier = Modifier
-                            .align(Alignment.End)
-                            .padding(horizontal = 16.dp, vertical = 4.dp),
-                        onClick = viewModel::clearFilters
-                    ) {
-                        Text(stringResource(R.string.btn_clear_filters))
-                    }
-                }
-            }
+            ExerciseFilterPanel(
+                availableFilters = uiState.availableFilters,
+                selectedFilters = uiState.selectedFilters,
+                onToggle = viewModel::toggleFilter,
+                onClear = viewModel::clearFilters,
+                modifier = Modifier.fillMaxWidth(),
+                initiallyExpanded = true
+            )
 
             when {
                 uiState.isLoading -> {

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/exercises/picker/ExercisePicker.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/exercises/picker/ExercisePicker.kt
@@ -26,9 +26,10 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.selection.toggleable
@@ -59,6 +60,7 @@ import com.noahjutz.gymroutines.R
 import com.noahjutz.gymroutines.ui.components.Chip
 import com.noahjutz.gymroutines.ui.components.SearchBar
 import com.noahjutz.gymroutines.ui.components.TopBar
+import com.noahjutz.gymroutines.ui.exercises.components.ExerciseFilterPanel
 import com.noahjutz.gymroutines.ui.exercises.list.ExerciseListItem
 import com.noahjutz.gymroutines.ui.exercises.detail.ExerciseDetailDialog
 import com.noahjutz.gymroutines.ui.exercises.detail.toDetailData
@@ -71,7 +73,7 @@ fun ExercisePickerSheet(
     onExercisesSelected: (List<Int>) -> Unit,
     navToExerciseEditor: () -> Unit,
 ) {
-    val allExercises by viewModel.allExercises.collectAsState()
+    val uiState by viewModel.uiState.collectAsState()
     val selectedExerciseIds by viewModel.selectedExerciseIdsFlow.collectAsState(initial = emptyList())
     var detailItem by remember { mutableStateOf<ExerciseListItem?>(null) }
 
@@ -88,7 +90,7 @@ fun ExercisePickerSheet(
             } else null
         )
     }
-    Column {
+    Column(modifier = Modifier.fillMaxSize()) {
         TopBar(
             title = stringResource(R.string.screen_pick_exercise),
             navigationIcon = {
@@ -105,19 +107,28 @@ fun ExercisePickerSheet(
                 }
             }
         )
-        val searchQuery by viewModel.nameFilter.collectAsState(initial = "")
         SearchBar(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(top = 16.dp, start = 16.dp, end = 16.dp),
-            value = searchQuery,
+            value = uiState.query,
             onValueChange = viewModel::search
         )
+        ExerciseFilterPanel(
+            availableFilters = uiState.availableFilters,
+            selectedFilters = uiState.selectedFilters,
+            onToggle = viewModel::toggleFilter,
+            onClear = viewModel::clearFilters,
+            modifier = Modifier.fillMaxWidth(),
+            initiallyExpanded = false
+        )
         LazyColumn(
-            modifier = Modifier.weight(1f),
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth(),
             contentPadding = PaddingValues(bottom = 16.dp)
         ) {
-            items(allExercises, key = { it.key }) { item ->
+            items(uiState.items, key = { it.key }) { item ->
                 val checked by viewModel.isSelected(item).collectAsState(initial = false)
                 ExercisePickerListItem(
                     item = item,

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/routines/editor/RoutineEditor.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/routines/editor/RoutineEditor.kt
@@ -429,7 +429,10 @@ private fun RoutineEditorContent(
                             }
                         }
                     }
-                    val trimmedNotes = remember(exercise.notes) { exercise.notes.trim() }
+                    val userNotes = remember(exercise.notes, exercise.libraryNotes) {
+                        if (exercise.notes == exercise.libraryNotes) "" else exercise.notes
+                    }
+                    val trimmedNotes = remember(userNotes) { userNotes.trim() }
                         if (trimmedNotes.isNotEmpty()) {
                             Surface(
                                 modifier = Modifier
@@ -442,12 +445,6 @@ private fun RoutineEditorContent(
                                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp),
                                 verticalAlignment = Alignment.CenterVertically
                             ) {
-                                Icon(
-                                    imageVector = Icons.Default.Edit,
-                                    contentDescription = stringResource(R.string.label_exercise_notes),
-                                    tint = colors.primary
-                                )
-                                Spacer(Modifier.width(12.dp))
                                 Text(
                                     text = trimmedNotes,
                                     style = typography.body2,
@@ -459,7 +456,7 @@ private fun RoutineEditorContent(
                                         notesEditorState = ExerciseNotesDialogState(
                                             exerciseId = exercise.exerciseId,
                                             name = exercise.name,
-                                            notes = exercise.notes
+                                            notes = userNotes
                                         )
                                     }
                                 ) {
@@ -479,7 +476,7 @@ private fun RoutineEditorContent(
                                 notesEditorState = ExerciseNotesDialogState(
                                     exerciseId = exercise.exerciseId,
                                     name = exercise.name,
-                                    notes = exercise.notes
+                                    notes = userNotes
                                 )
                             }
                         ) {

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/workout/in_progress/WorkoutInProgress.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/workout/in_progress/WorkoutInProgress.kt
@@ -403,7 +403,10 @@ private fun WorkoutInProgressContent(
                     }
 
                     if (exercise != null) {
-                        val trimmedNotes = remember(exercise.notes) { exercise.notes.trim() }
+                        val userNotes = remember(exercise.notes, exercise.libraryNotes) {
+                            if (exercise.notes == exercise.libraryNotes) "" else exercise.notes
+                        }
+                        val trimmedNotes = remember(userNotes) { userNotes.trim() }
                         val hasRestTimers = setGroup.group.restTimerWarmupSeconds > 0 ||
                             setGroup.group.restTimerWorkingSeconds > 0
                         val timerTint = if (hasRestTimers) colors.primary else colors.onSurface.copy(alpha = 0.6f)
@@ -419,12 +422,6 @@ private fun WorkoutInProgressContent(
                                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp),
                                     verticalAlignment = Alignment.CenterVertically
                                 ) {
-                                    Icon(
-                                        imageVector = Icons.Default.Edit,
-                                        contentDescription = stringResource(R.string.label_exercise_notes),
-                                        tint = colors.primary
-                                    )
-                                    Spacer(Modifier.width(12.dp))
                                     Text(
                                         text = trimmedNotes,
                                         style = typography.body2,
@@ -443,7 +440,7 @@ private fun WorkoutInProgressContent(
                                             notesEditorState = ExerciseNotesDialogState(
                                                 exerciseId = exercise.exerciseId,
                                                 name = exercise.name,
-                                                notes = exercise.notes
+                                                notes = userNotes
                                             )
                                         }
                                     ) {
@@ -462,18 +459,18 @@ private fun WorkoutInProgressContent(
                                     .fillMaxWidth(),
                                 verticalAlignment = Alignment.CenterVertically
                             ) {
-                                TextButton(
-                                    modifier = Modifier.weight(1f),
-                                    onClick = {
-                                        notesEditorState = ExerciseNotesDialogState(
-                                            exerciseId = exercise.exerciseId,
-                                            name = exercise.name,
-                                            notes = exercise.notes
-                                        )
-                                    }
-                                ) {
-                                    Icon(imageVector = Icons.Default.Edit, contentDescription = null)
-                                    Spacer(Modifier.width(8.dp))
+                                    TextButton(
+                                        modifier = Modifier.weight(1f),
+                                        onClick = {
+                                            notesEditorState = ExerciseNotesDialogState(
+                                                exerciseId = exercise.exerciseId,
+                                                name = exercise.name,
+                                                notes = userNotes
+                                            )
+                                        }
+                                    ) {
+                                        Icon(imageVector = Icons.Default.Edit, contentDescription = null)
+                                        Spacer(Modifier.width(8.dp))
                                     Text(stringResource(R.string.btn_add_notes))
                                 }
                                 Spacer(Modifier.width(4.dp))

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,7 +42,7 @@
     <string name="screen_insights">Insights</string>
     <string name="btn_new_exercise">New Exercise</string>
     <string name="menu_browse_exercise_library">Browse exercise library</string>
-    <string name="btn_add_to_my_exercises">Add to My Exercises</string>
+    <string name="btn_add_to_my_exercises">Save as Custom Exercise</string>
     <string name="hint_exercise_catalog">Browse the built-in library, tap an exercise to preview it, and add it to your list.</string>
     <string name="hint_exercise_catalog_empty">No exercises match your search yet.</string>
     <string name="label_search_suggestions">Suggestions</string>
@@ -74,6 +74,7 @@
     <string name="btn_save">Save</string>
     <string name="label_exercise_name">Exercise name</string>
     <string name="label_exercise_notes">Notes</string>
+    <string name="label_library_details">Library details</string>
     <string name="label_tracking_options">Tracking</string>
     <string name="btn_add_notes">Add notes</string>
     <string name="btn_edit_notes">Edit notes</string>
@@ -83,6 +84,9 @@
     <string name="unnamed_exercise">Unnamed exercise</string>
     <string name="btn_more">More</string>
     <string name="btn_clear_filters">Clear filters</string>
+    <string name="label_filter_options">Filters</string>
+    <string name="filters_show">Show filters</string>
+    <string name="filters_hide">Hide filters</string>
     <string name="btn_delete">Delete</string>
     <string name="dialog_item_set">this set</string>
     <string name="btn_select_option">Select</string>


### PR DESCRIPTION
## Summary
- store library exercise descriptions separately from user notes and migrate the schema
- make the exercise detail dialog fullscreen with GIF support and show stored library details
- add a reusable collapsible filter panel shared between the exercise list and picker while expanding the picker layout
- tidy routine and workout note displays so only user notes remain alongside rest timer actions

## Testing
- `./gradlew assembleDebug --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68e797e073608324a147f9c083b57021