### PR TITLE
Fix missing exercise GIF assets in generated index

### DIFF
--- a/buildSrc/src/main/kotlin/ExerciseIndexTask.kt
+++ b/buildSrc/src/main/kotlin/ExerciseIndexTask.kt
@@ -110,6 +110,28 @@ open class PrepareExerciseIndexTask : DefaultTask() {
             secondaryMuscles = entries.flatMap { it.secondaryMuscles }.toSortedSet().toList(),
         )
         metadataFile.writeText(json.encodeToString(metadata))
+
+        val mediaDir = File(sourceRoot, "media")
+        val referencedAssets = entries
+            .flatMap { entry ->
+                buildList {
+                    entry.heroAsset?.let { add(it) }
+                    addAll(entry.mediaAssets)
+                }
+            }
+            .mapNotNull { asset -> asset.removePrefix("media/").takeIf { asset.startsWith("media/") } }
+            .toSortedSet()
+
+        if (referencedAssets.isNotEmpty()) {
+            val outputMediaDir = File(containerDir, "media")
+            outputMediaDir.mkdirs()
+            referencedAssets.forEach { fileName ->
+                val sourceFile = File(mediaDir, fileName)
+                if (sourceFile.exists()) {
+                    sourceFile.copyTo(File(outputMediaDir, fileName), overwrite = true)
+                }
+            }
+        }
     }
 
     private fun findHeroAsset(id: String): String? {


### PR DESCRIPTION
## Summary
- copy referenced exercise media files into the generated exercise index output so GIF hero images are packaged with the offline assets

## Testing
- ./gradlew :app:prepareExerciseIndex

------
https://chatgpt.com/codex/tasks/task_e_68e7a2e7ed288324834eb48c7551675f