### PR TITLE
Remove custom exercise saves and always track load

### DIFF
--- a/app/src/main/java/com/noahjutz/gymroutines/data/domain/Exercise.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/data/domain/Exercise.kt
@@ -30,7 +30,7 @@ data class Exercise(
     @ColumnInfo(defaultValue = "")
     var libraryNotes: String = "",
     var logReps: Boolean = true,
-    var logWeight: Boolean = false,
+    var logWeight: Boolean = true,
     var logTime: Boolean = false,
     var logDistance: Boolean = false,
     var hidden: Boolean = false,

--- a/app/src/main/java/com/noahjutz/gymroutines/data/exerciselibrary/ExerciseLibraryMappers.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/data/exerciselibrary/ExerciseLibraryMappers.kt
@@ -3,12 +3,6 @@ package com.noahjutz.gymroutines.data.exerciselibrary
 import com.noahjutz.gymroutines.data.domain.Exercise
 import java.util.Locale
 
-private val bodyweightKeywords = setOf(
-    "body weight",
-    "bodyweight",
-    "no equipment"
-)
-
 private val distanceKeywords = setOf(
     "run",
     "row",
@@ -23,8 +17,6 @@ fun ExerciseLibraryEntry.toExercise(): Exercise {
     val equipments = equipments.map { it.trim() }.filter { it.isNotEmpty() }
     val primaryMuscles = targetMuscles.map { it.trim() }.filter { it.isNotEmpty() }
     val secondaryMuscleList = secondaryMuscles.map { it.trim() }.filter { it.isNotEmpty() }
-    val normalizedEquipments = equipments.map { it.lowercase(Locale.getDefault()) }
-    val isBodyweight = normalizedEquipments.isEmpty() || normalizedEquipments.all { it in bodyweightKeywords }
     val likelyDistance = primaryMuscles.any { muscle ->
         val normalized = muscle.lowercase(Locale.getDefault())
         distanceKeywords.any { keyword -> normalized.contains(keyword) }
@@ -68,7 +60,7 @@ fun ExerciseLibraryEntry.toExercise(): Exercise {
         notes = "",
         libraryNotes = libraryNotes,
         logReps = true,
-        logWeight = !isBodyweight,
+        logWeight = true,
         logTime = false,
         logDistance = likelyDistance,
         hidden = false,

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/exercises/catalog/ExerciseCatalog.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/exercises/catalog/ExerciseCatalog.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.AlertDialog
-import androidx.compose.material.Button
 import androidx.compose.material.Card
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.ExperimentalMaterialApi
@@ -33,7 +32,6 @@ import androidx.compose.material.TextButton
 import androidx.compose.material.rememberScaffoldState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material.icons.filled.LibraryAdd
 import androidx.compose.material.icons.filled.LibraryBooks
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -96,11 +94,7 @@ fun ExerciseCatalog(
     preview?.let { entry ->
         ExerciseDetailsDialog(
             entry = entry,
-            onDismiss = { preview = null },
-            onAdd = {
-                preview = null
-                viewModel.import(entry)
-            }
+            onDismiss = { preview = null }
         )
     }
 
@@ -124,8 +118,7 @@ fun ExerciseCatalog(
                 .padding(paddingValues),
             onQueryChange = viewModel::onQueryChanged,
             onSuggestionClicked = viewModel::onSuggestionSelected,
-            onPreview = { preview = it },
-            onImport = { viewModel.import(it) }
+            onPreview = { preview = it }
         )
     }
 }
@@ -138,7 +131,6 @@ private fun ExerciseCatalogContent(
     onQueryChange: (String) -> Unit,
     onSuggestionClicked: (String) -> Unit,
     onPreview: (ExerciseLibraryEntry) -> Unit,
-    onImport: (ExerciseLibraryEntry) -> Unit,
 ) {
     Column(
         modifier = modifier,
@@ -215,8 +207,7 @@ private fun ExerciseCatalogContent(
             items(state.exercises, key = { it.id }) { entry ->
                 ExerciseCatalogItem(
                     entry = entry,
-                    onPreview = { onPreview(entry) },
-                    onImport = { onImport(entry) }
+                    onPreview = { onPreview(entry) }
                 )
             }
         }
@@ -257,7 +248,6 @@ private fun SuggestionChip(
 private fun ExerciseCatalogItem(
     entry: ExerciseLibraryEntry,
     onPreview: () -> Unit,
-    onImport: () -> Unit,
 ) {
     Card(
         modifier = Modifier
@@ -296,12 +286,6 @@ private fun ExerciseCatalogItem(
                     overflow = TextOverflow.Ellipsis
                 )
             }
-            Spacer(modifier = Modifier.height(12.dp))
-            TextButton(onClick = onImport) {
-                Icon(Icons.Default.LibraryAdd, contentDescription = null)
-                Spacer(modifier = Modifier.width(6.dp))
-                Text(text = stringResource(R.string.btn_add_to_my_exercises))
-            }
         }
     }
 }
@@ -310,7 +294,6 @@ private fun ExerciseCatalogItem(
 private fun ExerciseDetailsDialog(
     entry: ExerciseLibraryEntry,
     onDismiss: () -> Unit,
-    onAdd: () -> Unit,
 ) {
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -368,14 +351,10 @@ private fun ExerciseDetailsDialog(
                 }
             }
         },
-        confirmButton = {
-            Button(onClick = onAdd) {
-                Text(stringResource(R.string.btn_add_to_my_exercises))
-            }
-        },
+        confirmButton = {},
         dismissButton = {
             TextButton(onClick = onDismiss) {
-                Text(stringResource(R.string.btn_cancel))
+                Text(stringResource(R.string.btn_close))
             }
         }
     )

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/exercises/detail/ExerciseDetailDialog.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/exercises/detail/ExerciseDetailDialog.kt
@@ -56,7 +56,6 @@ fun ExerciseDetailDialog(
     data: ExerciseDetailData,
     onDismiss: () -> Unit,
     onEdit: ((Int) -> Unit)? = null,
-    onSave: (() -> Unit)? = null,
 ) {
     val locale = remember { Locale.getDefault() }
     Dialog(onDismissRequest = onDismiss, properties = DialogProperties(usePlatformDefaultWidth = false)) {
@@ -81,7 +80,6 @@ fun ExerciseDetailDialog(
                             data = data,
                             locale = locale,
                             onEdit = onEdit,
-                            onSave = onSave
                         )
                         is ExerciseDetailData.Custom -> CustomExerciseDetail(
                             exercise = data.exercise,
@@ -109,7 +107,6 @@ private fun LibraryExerciseDetail(
     data: ExerciseDetailData.Library,
     locale: Locale,
     onEdit: ((Int) -> Unit)?,
-    onSave: (() -> Unit)?
 ) {
     val entry = data.entry
     val exercise = data.exercise
@@ -223,11 +220,6 @@ private fun LibraryExerciseDetail(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.End
         ) {
-            if (onSave != null && exercise == null) {
-                TextButton(onClick = onSave) {
-                    Text(stringResource(R.string.btn_add_to_my_exercises))
-                }
-            }
             if (onEdit != null) {
                 exercise?.let {
                     TextButton(onClick = { onEdit(it.exerciseId) }) {

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/exercises/editor/ExerciseEditorViewModel.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/exercises/editor/ExerciseEditorViewModel.kt
@@ -35,10 +35,10 @@ class ExerciseEditorViewModel(
     private val _notes = MutableStateFlow("")
     val notes = _notes.asStateFlow()
 
-    private val _logReps = MutableStateFlow(false)
+    private val _logReps = MutableStateFlow(true)
     val logReps = _logReps.asStateFlow()
 
-    private val _logWeight = MutableStateFlow(false)
+    private val _logWeight = MutableStateFlow(true)
     val logWeight = _logWeight.asStateFlow()
 
     private val _logTime = MutableStateFlow(false)
@@ -68,8 +68,8 @@ class ExerciseEditorViewModel(
                 _currentExercise.value = it
                 _name.value = it.name
                 _notes.value = it.notes
-                _logReps.value = it.logReps
-                _logWeight.value = it.logWeight
+                _logReps.value = true
+                _logWeight.value = true
                 _logTime.value = it.logTime
                 _logDistance.value = it.logDistance
             }
@@ -123,12 +123,12 @@ class ExerciseEditorViewModel(
         _notes.value = notes
     }
 
-    fun setLogReps(logReps: Boolean) {
-        _logReps.value = logReps
+    fun setLogReps(@Suppress("UNUSED_PARAMETER") logReps: Boolean) {
+        _logReps.value = true
     }
 
-    fun setLogWeight(logWeight: Boolean) {
-        _logWeight.value = logWeight
+    fun setLogWeight(@Suppress("UNUSED_PARAMETER") logWeight: Boolean) {
+        _logWeight.value = true
     }
 
     fun setLogTime(logTime: Boolean) {
@@ -145,8 +145,8 @@ class ExerciseEditorViewModel(
             val exercise = base.copy(
                 name = name.value,
                 notes = notes.value,
-                logReps = logReps.value,
-                logWeight = logWeight.value,
+                logReps = true,
+                logWeight = true,
                 logTime = logTime.value,
                 logDistance = logDistance.value,
                 hidden = false,

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/exercises/list/ExerciseList.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/exercises/list/ExerciseList.kt
@@ -79,15 +79,7 @@ fun ExerciseList(
                 onEdit = { exerciseId ->
                     detailItem = null
                     navToExerciseEditor(exerciseId)
-                },
-                onSave = if (item.exerciseId == null && item.entry != null) {
-                    {
-                        viewModel.ensureExercise(item.entry) { id ->
-                            detailItem = null
-                            navToExerciseEditor(id)
-                        }
-                    }
-                } else null
+                }
             )
         }
     }
@@ -177,13 +169,6 @@ fun ExerciseList(
                                                     ?: item.entry?.let { entry ->
                                                         viewModel.ensureExercise(entry) { navToExerciseEditor(it) }
                                                     }
-                                            },
-                                            onEnsure = {
-                                                item.entry?.let { entry ->
-                                                    viewModel.ensureExercise(entry) { id ->
-                                                        navToExerciseEditor(id)
-                                                    }
-                                                }
                                             }
                                         )
                                     }
@@ -212,13 +197,6 @@ fun ExerciseList(
                                         item.entry?.let { entry ->
                                             viewModel.ensureExercise(entry) { navToExerciseEditor(it) }
                                         }
-                                    },
-                                    onEnsure = {
-                                        item.entry?.let { entry ->
-                                            viewModel.ensureExercise(entry) { id ->
-                                                navToExerciseEditor(id)
-                                            }
-                                        }
                                     }
                                 )
                             }
@@ -236,7 +214,6 @@ private fun ExerciseListItemCard(
     item: ExerciseListItem,
     onShowDetail: () -> Unit,
     onEdit: () -> Unit,
-    onEnsure: () -> Unit,
 ) {
     Card(
         modifier = Modifier
@@ -272,14 +249,6 @@ private fun ExerciseListItemCard(
                             modifier = Modifier.padding(end = 8.dp, bottom = 8.dp)
                         )
                     }
-                }
-            }
-            if (item.exerciseId == null && item.entry != null) {
-                TextButton(
-                    modifier = Modifier.align(Alignment.End),
-                    onClick = onEnsure
-                ) {
-                    Text(stringResource(R.string.btn_add_to_my_exercises))
                 }
             }
         }

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/exercises/picker/ExercisePicker.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/exercises/picker/ExercisePicker.kt
@@ -81,13 +81,7 @@ fun ExercisePickerSheet(
         ExerciseDetailDialog(
             data = data,
             onDismiss = { detailItem = null },
-            onEdit = null,
-            onSave = if (detailItem?.exerciseId == null && detailItem?.entry != null) {
-                {
-                    detailItem?.let { viewModel.onSelectionChanged(it, true) }
-                    detailItem = null
-                }
-            } else null
+            onEdit = null
         )
     }
     Column(modifier = Modifier.fillMaxSize()) {

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/routines/editor/RoutineEditorViewModel.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/routines/editor/RoutineEditorViewModel.kt
@@ -116,6 +116,13 @@ class RoutineEditorViewModel(
         _routine?.let { routine ->
             viewModelScope.launch {
                 for (exerciseId in exerciseIds) {
+                    exerciseRepository.getExercise(exerciseId)?.let { exercise ->
+                        if (!exercise.logReps || !exercise.logWeight) {
+                            exerciseRepository.update(
+                                exercise.copy(logReps = true, logWeight = true)
+                            )
+                        }
+                    }
                     val setGroup = RoutineSetGroup(
                         exerciseId = exerciseId,
                         routineId = routine.routineId,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,7 +42,6 @@
     <string name="screen_insights">Insights</string>
     <string name="btn_new_exercise">New Exercise</string>
     <string name="menu_browse_exercise_library">Browse exercise library</string>
-    <string name="btn_add_to_my_exercises">Save as Custom Exercise</string>
     <string name="hint_exercise_catalog">Browse the built-in library, tap an exercise to preview it, and add it to your list.</string>
     <string name="hint_exercise_catalog_empty">No exercises match your search yet.</string>
     <string name="label_search_suggestions">Suggestions</string>


### PR DESCRIPTION
## Summary
- remove the "save as custom exercise" actions from the exercise detail dialog, list, picker, and catalog views
- require all exercises to track reps and load through the editor defaults, library imports, and routine additions
- drop the unused save-as string resource and simplify the library mapper logic

## Testing
- ./gradlew assembleDebug --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e7a6ae132483249bc060bd77cae625