### PR TITLE
Optimize workout timers and scope insights workloads

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -115,6 +115,7 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-common-java8:2.6.1")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1")
     implementation("androidx.lifecycle:lifecycle-process:2.6.1")
+    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.6.1")
 
     implementation("androidx.navigation:navigation-compose:2.6.0")
 

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/workout/insights/WorkoutInsights.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/workout/insights/WorkoutInsights.kt
@@ -35,8 +35,8 @@ import androidx.compose.material.icons.filled.ArrowDropUp
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Path
@@ -67,7 +67,7 @@ fun WorkoutInsights(
     navToConsistencyDetail: () -> Unit = {},
     navToRoutineHistory: (String) -> Unit = {},
 ) {
-    val state by viewModel.uiState.collectAsState()
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
 
     Scaffold(
         topBar = {


### PR DESCRIPTION
## Summary
- keep in-progress workout timing in memory and persist only on completion or teardown
- move insights aggregation to a background dispatcher, scope it with WhileSubscribed, and cache expensive name lookups
- collect insights UI state with lifecycle awareness and add the runtime-compose dependency needed for it

## Testing
- ./gradlew assembleDebug --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e7ab85f52c8324aa81a897865af630