### PR TITLE
Fix exercise search input and smooth scrolling

### DIFF
--- a/app/src/main/java/com/noahjutz/gymroutines/ui/components/SearchBar.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/components/SearchBar.kt
@@ -4,21 +4,19 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Surface
 import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.material.TextFieldDefaults
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.noahjutz.gymroutines.R
@@ -30,62 +28,56 @@ fun SearchBar(
     onValueChange: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    BasicTextField(
-        modifier = modifier,
+    val colors = MaterialTheme.colors
+    TextField(
         value = value,
         onValueChange = onValueChange,
+        modifier = modifier
+            .fillMaxWidth()
+            .height(48.dp),
         singleLine = true,
-        textStyle = MaterialTheme.typography.subtitle1.copy(color = MaterialTheme.colors.onSurface),
-        cursorBrush = SolidColor(MaterialTheme.colors.onSurface),
-        decorationBox = { innerTextField ->
-            Surface(
-                modifier = Modifier.height(48.dp),
-                color = MaterialTheme.colors.surface,
-                shape = MaterialTheme.shapes.large,
-                elevation = 2.dp,
-                border = BorderStroke(1.dp, MaterialTheme.colors.onSurface.copy(alpha = 0.06f))
+        textStyle = MaterialTheme.typography.subtitle1.copy(color = colors.onSurface),
+        shape = MaterialTheme.shapes.large,
+        placeholder = {
+            Text(
+                text = stringResource(R.string.hint_search),
+                style = MaterialTheme.typography.subtitle1.copy(
+                    color = colors.onSurface.copy(alpha = 0.38f)
+                )
+            )
+        },
+        leadingIcon = {
+            Icon(
+                imageVector = Icons.Default.Search,
+                contentDescription = null,
+                tint = colors.onSurface.copy(alpha = 0.65f)
+            )
+        },
+        trailingIcon = {
+            AnimatedVisibility(
+                visible = value.isNotEmpty(),
+                enter = fadeIn(),
+                exit = fadeOut()
             ) {
-                Row(
-                    Modifier.padding(horizontal = 16.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
+                IconButton(onClick = { onValueChange("") }) {
                     Icon(
-                        Icons.Default.Search,
-                        contentDescription = null,
-                        tint = MaterialTheme.colors.onSurface.copy(alpha = 0.65f)
+                        imageVector = Icons.Default.Clear,
+                        contentDescription = stringResource(R.string.btn_clear_text),
+                        tint = colors.onSurface.copy(alpha = 0.65f)
                     )
-                    Spacer(Modifier.width(10.dp))
-                    Box(
-                        Modifier
-                            .padding(vertical = 2.dp)
-                            .weight(1f)
-                    ) {
-                        if (value.isEmpty()) {
-                            Text(
-                                stringResource(R.string.hint_search),
-                                style = MaterialTheme.typography.subtitle1.copy(
-                                    color = MaterialTheme.colors.onSurface.copy(alpha = 0.38f)
-                                )
-                            )
-                        }
-                        innerTextField()
-                    }
-                    AnimatedVisibility(
-                        value.isNotEmpty(),
-                        enter = fadeIn(),
-                        exit = fadeOut()
-                    ) {
-                        Spacer(Modifier.width(6.dp))
-                        IconButton(onClick = { onValueChange("") }) {
-                            Icon(
-                                Icons.Default.Clear,
-                                stringResource(R.string.btn_clear_text),
-                                tint = MaterialTheme.colors.onSurface.copy(alpha = 0.65f)
-                            )
-                        }
-                    }
                 }
             }
-        }
+        },
+        colors = TextFieldDefaults.textFieldColors(
+            textColor = colors.onSurface,
+            cursorColor = colors.onSurface,
+            backgroundColor = colors.surface,
+            focusedIndicatorColor = androidx.compose.ui.graphics.Color.Transparent,
+            unfocusedIndicatorColor = androidx.compose.ui.graphics.Color.Transparent,
+            disabledIndicatorColor = androidx.compose.ui.graphics.Color.Transparent,
+            leadingIconColor = colors.onSurface.copy(alpha = 0.65f),
+            trailingIconColor = colors.onSurface.copy(alpha = 0.65f),
+            placeholderColor = colors.onSurface.copy(alpha = 0.38f)
+        )
     )
 }

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/routines/editor/RoutineEditor.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/routines/editor/RoutineEditor.kt
@@ -117,19 +117,21 @@ fun RoutineEditor(
             )
         }
     ) { paddingValues ->
-        val routine by viewModel.routine.collectAsState(initial = null)
-        Crossfade(routine != null, Modifier.padding(paddingValues)) { isReady ->
-            if (!isReady) {
+        val uiState by viewModel.uiState.collectAsState()
+        Crossfade(
+            targetState = uiState.routineWithSetGroups,
+            modifier = Modifier.padding(paddingValues)
+        ) { routineWithGroups ->
+            if (routineWithGroups == null) {
                 RoutineEditorPlaceholder()
             } else {
-                routine?.let { routine ->
-                    RoutineEditorContent(
-                        routine = routine.routine,
-                        setGroups = routine.setGroups,
-                        viewModel = viewModel,
-                        navToExercisePicker = navToExercisePicker
-                    )
-                }
+                RoutineEditorContent(
+                    routine = routineWithGroups.routine,
+                    setGroups = routineWithGroups.setGroups,
+                    exercisesById = uiState.exercisesById,
+                    viewModel = viewModel,
+                    navToExercisePicker = navToExercisePicker
+                )
             }
         }
     }
@@ -226,6 +228,7 @@ private data class ExerciseNotesDialogState(
 private fun RoutineEditorContent(
     routine: Routine,
     setGroups: List<RoutineSetGroupWithSets>,
+    exercisesById: Map<Int, Exercise>,
     viewModel: RoutineEditorViewModel,
     navToExercisePicker: () -> Unit
 ) {
@@ -335,9 +338,7 @@ private fun RoutineEditorContent(
         }
 
         items(sortedSetGroups, key = { it.group.id }) { setGroup ->
-            val exerciseState = viewModel.getExercise(setGroup.group.exerciseId)
-                .collectAsState(initial = null)
-            val exercise = exerciseState.value ?: return@items
+            val exercise = exercisesById[setGroup.group.exerciseId] ?: return@items
             val headerColor = lerp(colors.surface, colors.primary, 0.18f)
             Card(
                 Modifier

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/routines/editor/RoutineEditorViewModel.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/routines/editor/RoutineEditorViewModel.kt
@@ -32,11 +32,16 @@ import com.noahjutz.gymroutines.data.domain.Routine
 import com.noahjutz.gymroutines.data.domain.RoutineSet
 import com.noahjutz.gymroutines.data.domain.RoutineSetGroup
 import com.noahjutz.gymroutines.data.domain.RoutineSetGroupWithSets
+import com.noahjutz.gymroutines.data.domain.RoutineWithSetGroups
 import com.noahjutz.gymroutines.data.domain.Workout
 import com.noahjutz.gymroutines.data.domain.WorkoutSet
 import com.noahjutz.gymroutines.data.domain.WorkoutSetGroup
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 class RoutineEditorViewModel(
@@ -48,13 +53,28 @@ class RoutineEditorViewModel(
 ) : ViewModel() {
     val isWorkoutInProgress: Flow<Boolean> =
         preferences.data.map { it[AppPrefs.CurrentWorkout.key]?.let { it >= 0 } ?: false }
-    val routine = routineRepository.getRoutineWithSetGroups(routineId)
+    private val routineWithSetGroups = routineRepository.getRoutineWithSetGroups(routineId)
+    val routine = routineWithSetGroups
     private val _routineFlow = routineRepository.getRoutineFlow(routineId)
     private var _routine: Routine? = null
     private val _setsFlow = routineRepository.getSetsFlow(routineId)
     private var _sets = emptyList<RoutineSet>()
     private val _setGroupsFlow = routineRepository.getSetGroupsFlow(routineId)
     private var _setGroups = emptyList<RoutineSetGroup>()
+
+    val uiState: StateFlow<RoutineEditorUiState> = combine(
+        routineWithSetGroups,
+        exerciseRepository.exercises
+    ) { routineWithGroups, exercises ->
+        RoutineEditorUiState(
+            routineWithSetGroups = routineWithGroups,
+            exercisesById = exercises.associateBy { it.exerciseId }
+        )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5_000),
+        initialValue = RoutineEditorUiState()
+    )
 
     init {
         viewModelScope.launch {
@@ -248,3 +268,8 @@ class RoutineEditorViewModel(
         }
     }
 }
+
+data class RoutineEditorUiState(
+    val routineWithSetGroups: RoutineWithSetGroups? = null,
+    val exercisesById: Map<Int, Exercise> = emptyMap(),
+)


### PR DESCRIPTION
## Summary
- replace the bespoke `BasicTextField` search bar with a themed `TextField` so typed text is rendered reliably
- surface a memoized `uiState` from the routine and workout view models that bundles exercise lookups for list rendering
- update routine and workout editors to consume the cached exercise map and streamline Crossfades for smoother scrolling

## Testing
- `./gradlew assembleDebug --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68e7c3909c408324aafc06ff68def801