### PR TITLE
Fix exercise catalog search text reset while loading

### DIFF
--- a/app/src/main/java/com/noahjutz/gymroutines/ui/exercises/catalog/ExerciseCatalogViewModel.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/exercises/catalog/ExerciseCatalogViewModel.kt
@@ -60,7 +60,14 @@ class ExerciseCatalogViewModel(
         activeFilters: ExerciseCatalogFilters,
         sort: ExerciseSearchSortOption
     ) {
-        _state.update { it.copy(isLoading = true) }
+        _state.update {
+            it.copy(
+                isLoading = true,
+                query = query,
+                filters = activeFilters,
+                sort = sort
+            )
+        }
         val library = repository.ensureLoaded()
         val searchFilters = ExerciseSearchFilters(
             bodyParts = activeFilters.bodyParts,


### PR DESCRIPTION
## Summary
- keep the exercise catalog search bar text in state when triggering a refresh
- ensure loading updates also carry over the latest filters and sort selection

## Testing
- ./gradlew assembleDebug --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e7cca7ff5c83249a65a85ac15eaaad