### PR TITLE
Fix exercise catalog search input reset

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -154,6 +154,7 @@ dependencies {
 
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.assertj:assertj-core:3.24.2")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4")
 }
 
 ksp {

--- a/app/src/main/java/com/noahjutz/gymroutines/ui/exercises/catalog/ExerciseCatalogViewModel.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/ui/exercises/catalog/ExerciseCatalogViewModel.kt
@@ -60,7 +60,14 @@ class ExerciseCatalogViewModel(
         activeFilters: ExerciseCatalogFilters,
         sort: ExerciseSearchSortOption
     ) {
-        _state.update { it.copy(isLoading = true) }
+        _state.update {
+            it.copy(
+                isLoading = true,
+                query = query,
+                filters = activeFilters,
+                sort = sort
+            )
+        }
         val library = repository.ensureLoaded()
         val searchFilters = ExerciseSearchFilters(
             bodyParts = activeFilters.bodyParts,

--- a/app/src/test/java/com/noahjutz/gymroutines/MainDispatcherRule.kt
+++ b/app/src/test/java/com/noahjutz/gymroutines/MainDispatcherRule.kt
@@ -1,0 +1,23 @@
+package com.noahjutz.gymroutines
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainDispatcherRule(
+    val dispatcher: TestDispatcher = UnconfinedTestDispatcher()
+) : TestWatcher() {
+    override fun starting(description: Description) {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
+    }
+}

--- a/app/src/test/java/com/noahjutz/gymroutines/ui/exercises/catalog/ExerciseCatalogViewModelTest.kt
+++ b/app/src/test/java/com/noahjutz/gymroutines/ui/exercises/catalog/ExerciseCatalogViewModelTest.kt
@@ -1,0 +1,74 @@
+package com.noahjutz.gymroutines.ui.exercises.catalog
+
+import com.noahjutz.gymroutines.MainDispatcherRule
+import com.noahjutz.gymroutines.data.ExerciseRepository
+import com.noahjutz.gymroutines.data.exerciselibrary.ExerciseLibrary
+import com.noahjutz.gymroutines.data.exerciselibrary.ExerciseLibraryMetadata
+import com.noahjutz.gymroutines.data.exerciselibrary.ExerciseLibraryRepository
+import com.noahjutz.gymroutines.data.exerciselibrary.ExerciseSearchFilters
+import com.noahjutz.gymroutines.data.exerciselibrary.ExerciseSearchResult
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ExerciseCatalogViewModelTest {
+
+    @get:Rule
+    val dispatcherRule = MainDispatcherRule(StandardTestDispatcher())
+
+    @Test
+    fun queryRemainsVisibleWhileCatalogRefreshes() = runTest {
+        val libraryRepository = mockk<ExerciseLibraryRepository>()
+        val exerciseRepository = mockk<ExerciseRepository>()
+        val library = ExerciseLibrary(
+            entries = emptyList(),
+            metadata = ExerciseLibraryMetadata(
+                count = 0,
+                bodyParts = emptyList(),
+                equipments = emptyList(),
+                targetMuscles = emptyList(),
+                secondaryMuscles = emptyList()
+            )
+        )
+        val pendingResult = CompletableDeferred<ExerciseSearchResult>()
+
+        coEvery { libraryRepository.ensureLoaded() } returns library
+        coEvery {
+            libraryRepository.search(any(), any<ExerciseSearchFilters>(), any())
+        } coAnswers {
+            pendingResult.await()
+        }
+        every { exerciseRepository.exercises } returns MutableStateFlow(emptyList())
+
+        val viewModel = ExerciseCatalogViewModel(libraryRepository, exerciseRepository)
+
+        val query = "bench press"
+        viewModel.onQueryChanged(query)
+
+        runCurrent()
+
+        val loadingState = viewModel.state.value
+        assertTrue(loadingState.isLoading)
+        assertEquals(query, loadingState.query)
+
+        pendingResult.complete(ExerciseSearchResult(emptyList(), emptyList()))
+        advanceUntilIdle()
+
+        val finalState = viewModel.state.value
+        assertFalse(finalState.isLoading)
+        assertEquals(query, finalState.query)
+    }
+}


### PR DESCRIPTION
## Summary
- keep the exercise catalog search query and sort/filter selection while a new search loads
- add coroutine test utilities and a unit test covering the loading state behavior
- pull in kotlinx-coroutines-test for JVM unit tests

## Testing
- `./gradlew --console=plain test`
- `./gradlew --console=plain assembleDebug`


------
https://chatgpt.com/codex/tasks/task_e_68e7d4c726088324bd4fdb740a59f96d