### PR TITLE
Offload exercise catalog search to a background dispatcher

### DIFF
--- a/app/src/main/java/com/noahjutz/gymroutines/data/exerciselibrary/ExerciseLibraryRepository.kt
+++ b/app/src/main/java/com/noahjutz/gymroutines/data/exerciselibrary/ExerciseLibraryRepository.kt
@@ -55,7 +55,9 @@ class ExerciseLibraryRepository(
     ): ExerciseSearchResult {
         val library = ensureLoaded()
         val searchEngine = engine ?: ExerciseSearchEngine(library.entries).also { engine = it }
-        return searchEngine.search(query, filters, sort)
+        return withContext(Dispatchers.Default) {
+            searchEngine.search(query, filters, sort)
+        }
     }
 
     suspend fun getExercise(id: String): ExerciseLibraryEntry? {


### PR DESCRIPTION
## Summary
- run the exercise catalog search engine on Dispatchers.Default so each keystroke doesn’t block the UI thread

## Testing
- ./gradlew --no-daemon assembleDebug --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e7dcbc573083248a31108a41f5da7e